### PR TITLE
Add logo to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 <!-- PROJECT LOGO -->
 <br />
 <p align="center">
+
+  <img src="images/logo.svg" alt="Logo for PosturePerfection" width="250">
+
   <h1 align="center">PosturePerfection</h1>
 
   <p align="center">

--- a/images/logo.svg
+++ b/images/logo.svg
@@ -1,0 +1,237 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="110.25506mm"
+   height="65.765457mm"
+   viewBox="0 0 110.25506 65.765457"
+   version="1.1"
+   id="svg928"
+   inkscape:version="1.0.1 (0767f8302a, 2020-10-17)"
+   sodipodi:docname="posture-logo-font-paths.svg">
+  <defs
+     id="defs922">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient1587">
+      <stop
+         style="stop-color:#28f19c;stop-opacity:1;"
+         offset="0"
+         id="stop1583" />
+      <stop
+         style="stop-color:#28f19c;stop-opacity:0;"
+         offset="1"
+         id="stop1585" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient1581">
+      <stop
+         style="stop-color:#0ab3e4;stop-opacity:1;"
+         offset="0"
+         id="stop1577" />
+      <stop
+         style="stop-color:#28f19c;stop-opacity:1"
+         offset="1"
+         id="stop1579" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1581"
+       id="linearGradient1535"
+       x1="71.40007"
+       y1="178.44379"
+       x2="140.24144"
+       y2="161.34079"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1581"
+       id="linearGradient1537"
+       x1="97.907707"
+       y1="157.60271"
+       x2="144.66742"
+       y2="140.49971"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1587"
+       id="linearGradient1589"
+       x1="97.66021"
+       y1="157.60271"
+       x2="166.06323"
+       y2="157.60271"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1587"
+       id="linearGradient1591"
+       x1="71.267784"
+       y1="178.44379"
+       x2="161.87627"
+       y2="178.44379"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1581"
+       id="linearGradient1601"
+       x1="51.308147"
+       y1="149.92227"
+       x2="122.88167"
+       y2="131.06079"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1581"
+       id="linearGradient1603"
+       x1="38.718887"
+       y1="154.60654"
+       x2="122.88167"
+       y2="131.06079"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="1.4"
+     inkscape:cx="89.784933"
+     inkscape:cy="152.91474"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     inkscape:document-rotation="0"
+     showgrid="false"
+     inkscape:window-width="1920"
+     inkscape:window-height="1042"
+     inkscape:window-x="0"
+     inkscape:window-y="18"
+     inkscape:window-maximized="0"
+     lock-margins="true"
+     fit-margin-top="1"
+     fit-margin-left="1"
+     fit-margin-right="1"
+     fit-margin-bottom="1" />
+  <metadata
+     id="metadata925">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-37.718887,-123.8821)">
+    <path
+       style="fill:none;stroke:url(#linearGradient1603);stroke-width:5;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 73.434818,127.3821 c 0,0 -5.67518,26.59033 -7.834386,29.02737 -3.123849,3.52581 -14.682021,-1.55876 -17.083953,0 -2.947365,1.91272 -7.297592,25.42151 -7.297592,25.42151"
+       id="path1503"
+       sodipodi:nodetypes="cssc"
+       inkscape:export-xdpi="96"
+       inkscape:export-ydpi="96"
+       inkscape:export-filename="/home/mr/snap/inkscape/8049/text1513.png" />
+    <path
+       style="fill:none;stroke:url(#linearGradient1601);stroke-width:5;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 78.671448,135.28248 c 0,0 -5.62014,25.56911 -7.77935,28.00615 -3.12385,3.52581 -14.68202,-1.55876 -17.083952,0"
+       id="path1505"
+       sodipodi:nodetypes="csc"
+       inkscape:export-xdpi="96"
+       inkscape:export-ydpi="96"
+       inkscape:export-filename="/home/mr/snap/inkscape/8049/text1513.png" />
+    <g
+       aria-label="Posture"
+       transform="skewX(-7)"
+       id="text1509"
+       style="font-style:normal;font-weight:normal;font-size:19.7556px;line-height:1.25;font-family:sans-serif;fill:url(#linearGradient1537);fill-opacity:1;stroke:none;stroke-width:0.494998;stroke-opacity:1">
+      <path
+         d="m 104.17024,150.58946 h -4.346237 l -1.916293,13.69063 h 3.18065 l 0.63218,-4.56354 h 1.50143 c 4.44501,0 6.02545,-2.8053 6.02545,-5.31426 0,-2.54847 -1.91629,-3.81283 -5.07718,-3.81283 z m -0.96803,6.79593 h -1.14582 l 0.61242,-4.48453 h 1.18534 c 1.36313,0 2.09409,0.49389 2.09409,1.65948 0,1.22484 -0.5334,2.82505 -2.74603,2.82505 z"
+         style="font-style:italic;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:19.7556px;font-family:'Fira Sans';-inkscape-font-specification:'Fira Sans Bold Italic';fill:url(#linearGradient1537);fill-opacity:1;stroke:none;stroke-width:0.494998;stroke-opacity:1"
+         id="path848" />
+      <path
+         d="m 115.06082,153.45402 c -4.42526,0 -5.84766,3.77332 -5.84766,6.69715 0,2.78554 1.6002,4.46477 4.38574,4.46477 4.4055,0 5.82791,-3.81284 5.84766,-6.69715 0.0198,-2.74603 -1.6002,-4.46477 -4.38574,-4.46477 z m -0.21731,2.29165 c 0.96802,0 1.46191,0.59267 1.44216,1.97556 0,1.6002 -0.41487,4.60306 -2.46945,4.60306 -0.96803,0 -1.46192,-0.59267 -1.46192,-1.97556 0,-1.60021 0.41487,-4.60306 2.48921,-4.60306 z"
+         style="font-style:italic;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:19.7556px;font-family:'Fira Sans';-inkscape-font-specification:'Fira Sans Bold Italic';fill:url(#linearGradient1537);fill-opacity:1;stroke:none;stroke-width:0.494998;stroke-opacity:1"
+         id="path850" />
+      <path
+         d="m 125.33805,153.45402 c -2.88432,0 -4.42525,1.58045 -4.42525,3.37821 0,1.56069 0.86924,2.42994 2.667,3.04236 1.65947,0.57291 2.07434,0.77047 2.07434,1.46192 0,0.57291 -0.5334,1.04704 -1.61996,1.04704 -1.18533,0 -2.1336,-0.49389 -2.82505,-1.10631 l -1.56069,1.61996 c 0.90876,0.98778 2.4892,1.71874 4.36599,1.71874 3.23991,0 4.70183,-1.69899 4.70183,-3.65479 0,-1.63972 -0.94827,-2.60774 -2.72627,-3.18065 -1.60021,-0.51365 -2.01507,-0.69145 -2.01507,-1.2446 0,-0.51365 0.45437,-0.8495 1.38289,-0.8495 0.82973,0 1.71873,0.27658 2.46945,0.79023 l 1.36313,-1.67923 c -0.94827,-0.80998 -2.27189,-1.34338 -3.85234,-1.34338 z"
+         style="font-style:italic;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:19.7556px;font-family:'Fira Sans';-inkscape-font-specification:'Fira Sans Bold Italic';fill:url(#linearGradient1537);fill-opacity:1;stroke:none;stroke-width:0.494998;stroke-opacity:1"
+         id="path852" />
+      <path
+         d="m 134.3003,155.96298 h 2.05459 l 0.61242,-2.17311 h -2.37067 l 0.37535,-2.6275 -2.64725,0.29634 -0.65193,2.33116 h -1.58045 l -0.29633,2.17311 h 1.44216 l -0.69145,4.84012 c -0.33585,2.4497 0.61242,3.79308 2.92383,3.81284 0.889,0 1.99531,-0.25683 2.88432,-0.77047 l -0.82974,-2.05459 c -0.41487,0.23707 -0.80998,0.33585 -1.18534,0.33585 -0.61242,0 -0.84949,-0.31609 -0.7112,-1.32363 z"
+         style="font-style:italic;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:19.7556px;font-family:'Fira Sans';-inkscape-font-specification:'Fira Sans Bold Italic';fill:url(#linearGradient1537);fill-opacity:1;stroke:none;stroke-width:0.494998;stroke-opacity:1"
+         id="path854" />
+      <path
+         d="m 147.41709,153.78987 h -3.06211 l -0.92852,6.63788 c -0.57291,0.92851 -1.28411,1.69898 -2.01507,1.69898 -0.57291,0 -0.82973,-0.27658 -0.69144,-1.34338 l 0.96802,-6.99348 h -3.06212 l -1.0668,7.50712 c -0.27658,2.01508 0.5334,3.31895 2.48921,3.31895 1.34338,0 2.42993,-0.75072 3.31894,-1.89654 l -0.0593,1.56069 h 2.64725 z"
+         style="font-style:italic;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:19.7556px;font-family:'Fira Sans';-inkscape-font-specification:'Fira Sans Bold Italic';fill:url(#linearGradient1537);fill-opacity:1;stroke:none;stroke-width:0.494998;stroke-opacity:1"
+         id="path856" />
+      <path
+         d="m 155.42799,153.49353 c -1.08656,0 -2.25214,0.80998 -2.96334,2.25214 l 0.0395,-1.9558 h -2.667 l -1.46192,10.49022 h 3.06212 l 0.69145,-4.85988 c 0.57291,-1.65947 1.28411,-2.90407 2.58798,-2.90407 0.31609,0 0.55316,0.0593 0.86925,0.13829 l 0.889,-3.00285 c -0.33585,-0.0988 -0.63218,-0.15805 -1.04705,-0.15805 z"
+         style="font-style:italic;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:19.7556px;font-family:'Fira Sans';-inkscape-font-specification:'Fira Sans Bold Italic';fill:url(#linearGradient1537);fill-opacity:1;stroke:none;stroke-width:0.494998;stroke-opacity:1"
+         id="path858" />
+      <path
+         d="m 165.81573,156.31858 c 0,-1.58044 -1.32362,-2.86456 -3.87209,-2.86456 -4.4055,0 -5.94644,3.8721 -5.94644,6.71691 0,2.667 1.50143,4.44501 4.56354,4.44501 1.61996,0 3.02261,-0.57292 4.16843,-1.40265 l -1.10631,-1.85703 c -0.96802,0.65194 -1.778,0.96803 -2.667,0.96803 -1.0273,0 -1.77801,-0.47414 -1.85703,-1.85703 3.27943,-0.31609 6.7169,-1.20509 6.7169,-4.14868 z m -6.57861,2.25214 c 0.25682,-1.50142 0.94827,-3.04236 2.41018,-3.04236 0.82974,0 1.0668,0.49389 1.0668,0.96802 0,0.88901 -0.86924,1.87679 -3.47698,2.07434 z"
+         style="font-style:italic;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:19.7556px;font-family:'Fira Sans';-inkscape-font-specification:'Fira Sans Bold Italic';fill:url(#linearGradient1537);fill-opacity:1;stroke:none;stroke-width:0.494998;stroke-opacity:1"
+         id="path860" />
+    </g>
+    <g
+       aria-label="Perfection"
+       transform="skewX(-7)"
+       id="text1513"
+       style="font-style:normal;font-weight:normal;font-size:19.7556px;line-height:1.25;font-family:sans-serif;fill:url(#linearGradient1535);fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1">
+      <path
+         d="m 77.662598,170.57118 h -4.346232 l -1.916293,13.69063 h 3.180652 l 0.632179,-4.56354 h 1.501425 c 4.44501,0 6.025458,-2.8053 6.025458,-5.31426 0,-2.54847 -1.916293,-3.81283 -5.077189,-3.81283 z m -0.968024,6.79593 h -1.145825 l 0.612424,-4.48453 h 1.185336 c 1.363136,0 2.094093,0.49389 2.094093,1.65948 0,1.22484 -0.533401,2.82505 -2.746028,2.82505 z"
+         style="font-style:italic;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:19.7556px;font-family:'Fira Sans';-inkscape-font-specification:'Fira Sans Bold Italic';fill:url(#linearGradient1535);fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
+         id="path863" />
+      <path
+         d="m 92.504301,176.3003 c 0,-1.58044 -1.323625,-2.86456 -3.872098,-2.86456 -4.405498,0 -5.946435,3.8721 -5.946435,6.71691 0,2.667 1.501425,4.44501 4.563543,4.44501 1.61996,0 3.022607,-0.57292 4.168432,-1.40265 l -1.106314,-1.85703 c -0.968024,0.65194 -1.778004,0.96803 -2.667006,0.96803 -1.027291,0 -1.778004,-0.47414 -1.857026,-1.85703 3.27943,-0.31609 6.716904,-1.20509 6.716904,-4.14868 z m -6.578615,2.25214 c 0.256823,-1.50142 0.948269,-3.04236 2.410183,-3.04236 0.829736,0 1.066803,0.49389 1.066803,0.96802 0,0.88901 -0.869247,1.87679 -3.476986,2.07434 z"
+         style="font-style:italic;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:19.7556px;font-family:'Fira Sans';-inkscape-font-specification:'Fira Sans Bold Italic';fill:url(#linearGradient1535);fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
+         id="path865" />
+      <path
+         d="m 100.25158,173.47525 c -1.086555,0 -2.252136,0.80998 -2.963337,2.25214 l 0.03951,-1.9558 h -2.667006 l -1.461915,10.49022 h 3.062118 l 0.691446,-4.85988 c 0.572913,-1.65947 1.284114,-2.90407 2.587984,-2.90407 0.31609,0 0.553159,0.0593 0.869249,0.13829 l 0.889,-3.00285 c -0.33585,-0.0988 -0.63218,-0.15805 -1.04705,-0.15805 z"
+         style="font-style:italic;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:19.7556px;font-family:'Fira Sans';-inkscape-font-specification:'Fira Sans Bold Italic';fill:url(#linearGradient1535);fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
+         id="path867" />
+      <path
+         d="m 107.49355,171.57872 c 0.45438,0 1.04705,0.079 1.58045,0.43462 l 1.08656,-1.87678 c -0.7112,-0.47414 -1.65947,-0.86925 -2.92383,-0.86925 -2.54847,0 -4.03014,1.52118 -4.30672,3.53625 l -0.13829,0.96803 h -1.56069 l -0.29634,2.17311 h 1.5607 l -1.02729,7.28982 c -0.25683,1.91629 -1.08656,2.58798 -2.568232,3.1609 l 0.770469,2.25213 c 2.528713,-0.90875 4.405503,-2.11385 4.879633,-5.53156 l 1.00754,-7.17129 h 2.11384 l 0.63218,-2.17311 h -2.42994 l 0.0988,-0.77047 c 0.13829,-1.00754 0.61243,-1.4224 1.52118,-1.4224 z"
+         style="font-style:italic;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:19.7556px;font-family:'Fira Sans';-inkscape-font-specification:'Fira Sans Bold Italic';fill:url(#linearGradient1535);fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
+         id="path869" />
+      <path
+         d="m 117.4689,176.3003 c 0,-1.58044 -1.32363,-2.86456 -3.8721,-2.86456 -4.4055,0 -5.94644,3.8721 -5.94644,6.71691 0,2.667 1.50143,4.44501 4.56355,4.44501 1.61996,0 3.0226,-0.57292 4.16843,-1.40265 l -1.10631,-1.85703 c -0.96803,0.65194 -1.77801,0.96803 -2.66701,0.96803 -1.02729,0 -1.778,-0.47414 -1.85703,-1.85703 3.27943,-0.31609 6.71691,-1.20509 6.71691,-4.14868 z m -6.57862,2.25214 c 0.25682,-1.50142 0.94827,-3.04236 2.41019,-3.04236 0.82973,0 1.0668,0.49389 1.0668,0.96802 0,0.88901 -0.86925,1.87679 -3.47699,2.07434 z"
+         style="font-style:italic;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:19.7556px;font-family:'Fira Sans';-inkscape-font-specification:'Fira Sans Bold Italic';fill:url(#linearGradient1535);fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
+         id="path871" />
+      <path
+         d="m 124.09011,173.43574 c -4.26721,0 -5.86742,3.91161 -5.86742,6.63788 0,2.76579 1.63972,4.52404 4.46477,4.52404 1.40265,0 2.56823,-0.43463 3.61527,-1.2051 l -1.14582,-1.99531 c -0.77047,0.47413 -1.32363,0.73096 -2.07434,0.73096 -0.98778,0 -1.63971,-0.45438 -1.63971,-1.93605 0,-1.77801 0.5334,-4.36599 2.667,-4.36599 0.67169,0 1.24461,0.19756 1.81752,0.73096 l 1.52118,-1.77801 c -0.86925,-0.889 -2.01507,-1.34338 -3.35845,-1.34338 z"
+         style="font-style:italic;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:19.7556px;font-family:'Fira Sans';-inkscape-font-specification:'Fira Sans Bold Italic';fill:url(#linearGradient1535);fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
+         id="path873" />
+      <path
+         d="m 131.94697,175.9447 h 2.05458 l 0.61243,-2.17311 h -2.37067 l 0.37535,-2.6275 -2.64725,0.29634 -0.65193,2.33116 h -1.58045 l -0.29634,2.17311 h 1.44216 l -0.69144,4.84012 c -0.33585,2.4497 0.61242,3.79308 2.92383,3.81284 0.889,0 1.99531,-0.25683 2.88431,-0.77047 l -0.82973,-2.05459 c -0.41487,0.23707 -0.80998,0.33585 -1.18534,0.33585 -0.61242,0 -0.84949,-0.31609 -0.7112,-1.32363 z"
+         style="font-style:italic;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:19.7556px;font-family:'Fira Sans';-inkscape-font-specification:'Fira Sans Bold Italic';fill:url(#linearGradient1535);fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
+         id="path875" />
+      <path
+         d="m 138.62344,168.24002 c -1.02729,0 -1.85703,0.75071 -1.99532,1.71874 -0.13828,1.02729 0.51365,1.83727 1.60021,1.83727 1.0668,0 1.87678,-0.73096 2.01507,-1.69898 0.13829,-1.04705 -0.51365,-1.85703 -1.61996,-1.85703 z m 0.80998,5.53157 h -3.06212 l -1.46191,10.49022 h 3.06212 z"
+         style="font-style:italic;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:19.7556px;font-family:'Fira Sans';-inkscape-font-specification:'Fira Sans Bold Italic';fill:url(#linearGradient1535);fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
+         id="path877" />
+      <path
+         d="m 146.31516,173.43574 c -4.42526,0 -5.84766,3.77332 -5.84766,6.69715 0,2.78554 1.60021,4.46477 4.38574,4.46477 4.4055,0 5.82791,-3.81284 5.84766,-6.69715 0.0198,-2.74603 -1.6002,-4.46477 -4.38574,-4.46477 z m -0.21731,2.29165 c 0.96802,0 1.46191,0.59267 1.44216,1.97556 0,1.6002 -0.41487,4.60306 -2.46945,4.60306 -0.96803,0 -1.46192,-0.59267 -1.46192,-1.97556 0,-1.60021 0.41487,-4.60306 2.48921,-4.60306 z"
+         style="font-style:italic;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:19.7556px;font-family:'Fira Sans';-inkscape-font-specification:'Fira Sans Bold Italic';fill:url(#linearGradient1535);fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
+         id="path879" />
+      <path
+         d="m 159.37793,173.43574 c -1.40265,0 -2.68676,0.86925 -3.57576,2.17312 l 0.0593,-1.83727 h -2.667 l -1.46192,10.49022 h 3.06212 l 0.80998,-5.76863 c 0.75071,-1.48167 1.54094,-2.50897 2.33116,-2.50897 0.45438,0 0.75071,0.27658 0.61242,1.34338 l -0.98778,6.93422 h 3.08188 l 1.04704,-7.58615 c 0.29634,-2.03483 -0.63218,-3.23992 -2.3114,-3.23992 z"
+         style="font-style:italic;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:19.7556px;font-family:'Fira Sans';-inkscape-font-specification:'Fira Sans Bold Italic';fill:url(#linearGradient1535);fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
+         id="path881" />
+    </g>
+  </g>
+</svg>


### PR DESCRIPTION
Simple update to add the logo to the README.

It's added as an .svg file, which should render nicely in all modern browsers.