### PR TITLE
Add copyright to pass CI

### DIFF
--- a/src/doubler.cpp
+++ b/src/doubler.cpp
@@ -1,3 +1,23 @@
+/**
+ * @file doubler.h
+ *
+ * @copyright Copyright (C) 2021  Miklas Riechmann
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
 #include "doubler.h"
 
 int doubler(int x) { return x * 2; }

--- a/src/doubler.h
+++ b/src/doubler.h
@@ -1,3 +1,23 @@
+/**
+ * @file doubler.h
+ *
+ * @copyright Copyright (C) 2021  Miklas Riechmann
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
 #ifndef SRC_DOUBLER_H_
 #define SRC_DOUBLER_H_
 int doubler(int x);


### PR DESCRIPTION
# Details

- Minor fix to pass CI
- Adds copyright/license to top of doubler files
- (Other headers will be updated with #45)

# Checklist
- [x] I have run `cpplint` locally