### PR TITLE
Add body part averaging to post processor

### DIFF
--- a/src/intermediate_structures.h
+++ b/src/intermediate_structures.h
@@ -55,6 +55,24 @@ enum BodyPart {
   BodyPartMax = left_ankle
 };
 
+/**
+ * @brief Defines order of joints in any body part arrays
+ *
+ * This is to be used where the pose is represented as a profile view to define
+ * the posture. As a result there are no left and right versions
+ *
+ */
+enum Joint {
+  Head = 0,
+  JointMin = Head,
+  Neck = 1,
+  Shoulder = 2,
+  Hip = 3,
+  Knee = 4,
+  Foot = 5,
+  JointMax = Foot
+};
+
 namespace PreProcessing {
 /**
  * @brief A structure of the pre processed image
@@ -66,7 +84,7 @@ namespace PreProcessing {
 struct PreProcessedImage {
   float* image;
 };
-};  // namespace PreProcessing
+}  // namespace PreProcessing
 
 namespace PostProcessing {
 
@@ -103,9 +121,11 @@ struct Coordinate {
  * is not necessarily the same as the output of the pose estimation model for
  * a given frame.
  *
+ * Iterate over this using the `Joint` enum
+ *
  */
 struct ProcessedResults {
-  std::array<Coordinate, BodyPartMax + 1> body_parts;
+  std::array<Coordinate, JointMax + 1> body_parts;
 };
 }  // namespace PostProcessing
 

--- a/src/post_processor.cpp
+++ b/src/post_processor.cpp
@@ -24,6 +24,41 @@
 #define MIN_CONF_THRESH 0.0  // Minimum value a confidence threshold can be
 #define MAX_CONF_THRESH 1.0  // Maximum value a confidence threshold can be
 
+/**
+ * @brief Take the mean of two body parts
+ *
+ * Intended for use with two body parts that lie left and right of the spine
+ * (as an axis of symmetry). As the system is for use with the person in
+ * profile, these should overlap, but there may be slight differences.
+ *
+ * If both input `PostProcessing::Coordinate`s are
+ * `PostProcessing::Trustworthy` the arithmetic mean of the two is returned (x
+ * and y coordinates are averaged independently). If only one body part is
+ * `PostProcessing::Trustworthy` only that body part is returned, i.e., no
+ * averaging takes place. In the case where both are
+ * `PostProcessing::Untrustworthy`, the mean is returned, although this may
+ * not be particularly meaningful as indicated by the `Untrustworthy` flag.
+ *
+ * @param left a `Inference::Coordinate`
+ * @param right a `Inference::Coordinate`
+ * @return `PostProcessing::Coordinate` the "intelligent" mean
+ */
+PostProcessing::Coordinate intelligent_mean_body_parts(
+    PostProcessing::Coordinate left, PostProcessing::Coordinate right) {
+  if (left.status == PostProcessing::Trustworthy &&
+      right.status == PostProcessing::Untrustworthy) {
+    return left;
+  } else if (left.status == PostProcessing::Untrustworthy &&
+             right.status == PostProcessing::Trustworthy) {
+    return right;
+  } else {
+    // Both Trustworthy or Untrustworthy
+    float x = (left.x + right.x) / 2;
+    float y = (left.y + right.y) / 2;
+    return PostProcessing::Coordinate{x, y, left.status};
+  }
+}
+
 namespace PostProcessing {
 
 PostProcessor::PostProcessor(float confidence_threshold,
@@ -39,6 +74,7 @@ PostProcessor::PostProcessor(float confidence_threshold,
 ProcessedResults PostProcessor::run(
     Inference::InferenceResults inference_core_output) {
   // Initialise structure for results
+  std::array<Coordinate, BodyPartMax + 1> intermediate_results;
   ProcessedResults results;
 
   /* Go through all of the body parts and apply the two IIR filters to the
@@ -49,6 +85,7 @@ ProcessedResults PostProcessor::run(
   int body_part_index = BodyPartMin;
   int filter_index = 0;
   Inference::Coordinate body_part;
+  Coordinate processed_body_part;
 
   for (; body_part_index < BodyPartMax + 1;
        body_part_index++, filter_index += 2) {
@@ -60,13 +97,44 @@ ProcessedResults PostProcessor::run(
     body_part.x = this->iir_filters.at(filter_index).run(body_part.x);
     body_part.y = this->iir_filters.at(filter_index + 1).run(body_part.y);
 
-    // Construct a `PostProcessing::Coordinate` with the filtered data
-    results.body_parts.at(body_part_index) =
+    processed_body_part =
         Coordinate{body_part.x, body_part.y,
                    (body_part.confidence > this->confidence_threshold)
                        ? Status::Trustworthy
                        : Status::Untrustworthy};
+    intermediate_results.at(body_part_index) = processed_body_part;
   }
+
+  // Assemble results with the filtered data and any necessary averaging
+  // Head
+  results.body_parts.at(Head) = intermediate_results.at(head_top);
+
+  // Neck
+  results.body_parts.at(Neck) = intermediate_results.at(upper_neck);
+
+  // Shoulder
+  Coordinate mean_shoulder =
+      intelligent_mean_body_parts(intermediate_results.at(left_shoulder),
+                                  intermediate_results.at(right_shoulder));
+  results.body_parts.at(Shoulder) = mean_shoulder;
+
+  // Hip (from left/right hip and pelvis)
+  Coordinate mean_hip = intelligent_mean_body_parts(
+      intermediate_results.at(left_hip), intermediate_results.at(right_hip));
+  mean_hip =
+      intelligent_mean_body_parts(mean_hip, intermediate_results.at(pelvis));
+  results.body_parts.at(Hip) = mean_hip;
+
+  // Knee
+  Coordinate mean_knee = intelligent_mean_body_parts(
+      intermediate_results.at(left_knee), intermediate_results.at(right_knee));
+  results.body_parts.at(Knee) = mean_knee;
+
+  // Foot (from ankles)
+  Coordinate mean_ankle =
+      intelligent_mean_body_parts(intermediate_results.at(left_ankle),
+                                  intermediate_results.at(right_ankle));
+  results.body_parts.at(Foot) = mean_ankle;
 
   return results;
 }

--- a/src/post_processor.h
+++ b/src/post_processor.h
@@ -39,6 +39,8 @@ namespace PostProcessing {
  * performed to process the raw data:
  * - Disregarding of any predictions below a given confidence threshold
  * - Smoothing location predictions in time
+ * - Averaging location of left and right body parts if both exceed the
+ * confidence threshold
  *
  */
 class PostProcessor {

--- a/test/test_post_processor.cpp
+++ b/test/test_post_processor.cpp
@@ -16,6 +16,16 @@ bool check_coords_match(PostProcessing::Coordinate result,
   return result.x == input.x && result.y == input.y;
 }
 
+float mean_of_coords_x(Inference::Coordinate input_left,
+                       Inference::Coordinate input_right) {
+  return (input_left.x + input_right.x) / 2;
+}
+
+float mean_of_coords_y(Inference::Coordinate input_left,
+                       Inference::Coordinate input_right) {
+  return (input_left.y + input_right.y) / 2;
+}
+
 BOOST_AUTO_TEST_CASE(LowConfidenceLabelledAsUntrustWorthy) {
   IIR::SmoothingSettings settings =
       IIR::SmoothingSettings{std::vector<std::vector<float>>{}};
@@ -73,19 +83,19 @@ BOOST_AUTO_TEST_CASE(CoordinatesPassedThroughWhenNotFiltered) {
 
   Inference::InferenceResults dummy_input;
   dummy_input.body_parts = {
-      Inference::Coordinate{0.1, 0.2, 0},
-      Inference::Coordinate{0.17, 0.18, 0},
-      Inference::Coordinate{0.3, 0.4, 0},
-      Inference::Coordinate{0.19, 0.201, 0},
-      Inference::Coordinate{0.5, 0.6, 0},
-      Inference::Coordinate{0.21, 0.22, 0},
+      Inference::Coordinate{0.1, 0.2, 1},
+      Inference::Coordinate{0.17, 0.18, 1},
+      Inference::Coordinate{0.3, 0.4, 1},
+      Inference::Coordinate{0.19, 0.201, 1},
+      Inference::Coordinate{0.5, 0.6, 1},
+      Inference::Coordinate{0.21, 0.22, 1},
       Inference::Coordinate{0.7, 0.8, 0},
       Inference::Coordinate{0.23, 0.24, 0},
       Inference::Coordinate{0.9, 0.101, 0},
       Inference::Coordinate{0.25, 0.26, 0},
-      Inference::Coordinate{0.11, 0.12, 0},
-      Inference::Coordinate{0.27, 0.28, 0},
-      Inference::Coordinate{0.13, 0.14, 0},
+      Inference::Coordinate{0.11, 0.12, 1},
+      Inference::Coordinate{0.27, 0.28, 1},
+      Inference::Coordinate{0.13, 0.14, 1},
       Inference::Coordinate{0.29, 0.301, 0},
       Inference::Coordinate{0.15, 0.16, 0},
       Inference::Coordinate{0.31, 0.32, 0},
@@ -93,10 +103,61 @@ BOOST_AUTO_TEST_CASE(CoordinatesPassedThroughWhenNotFiltered) {
 
   PostProcessing::ProcessedResults output = post_proc.run(dummy_input);
 
-  int body_part_index = BodyPartMin;
-  for (auto body_part : output.body_parts) {
-    BOOST_TEST(
-        check_coords_match(body_part, dummy_input.body_parts[body_part_index]));
-    body_part_index++;
-  }
+  check_coords_match(output.body_parts[Head], dummy_input.body_parts[head_top]);
+  check_coords_match(output.body_parts[Neck],
+                     dummy_input.body_parts[upper_neck]);
+  check_coords_match(output.body_parts[Shoulder],
+                     dummy_input.body_parts[right_shoulder]);
+  check_coords_match(output.body_parts[Hip], dummy_input.body_parts[right_hip]);
+  check_coords_match(output.body_parts[Knee],
+                     dummy_input.body_parts[right_knee]);
+  check_coords_match(output.body_parts[Foot],
+                     dummy_input.body_parts[right_ankle]);
+}
+
+BOOST_AUTO_TEST_CASE(AverageCoordinatesWhenBothTrustworthy) {
+  IIR::SmoothingSettings settings =
+      IIR::SmoothingSettings{std::vector<std::vector<float>>{}};
+  PostProcessing::PostProcessor post_proc =
+      PostProcessing::PostProcessor(0.0, settings);
+
+  Inference::InferenceResults dummy_input;
+  dummy_input.body_parts = {
+      Inference::Coordinate{0, 0, 1.0},
+      Inference::Coordinate{0, 0, 1.0},
+      Inference::Coordinate{0, 0, 1.0},  // Right shoulder
+      Inference::Coordinate{0, 0, 1.0},
+      Inference::Coordinate{0, 0, 1.0},
+      Inference::Coordinate{0, 0, 1.0},
+      Inference::Coordinate{1, 1, 1.0},  // Left shoulder
+      Inference::Coordinate{0, 0, 1.0},
+      Inference::Coordinate{0, 0, 1.0},
+      Inference::Coordinate{0, 0, 1.0},  // Pelvis
+      Inference::Coordinate{0, 0, 1.0},  // Right hip
+      Inference::Coordinate{0, 0, 1.0},
+      Inference::Coordinate{0, 0, 1.0},
+      Inference::Coordinate{0.5, 0.5, 1.0},  // Left hip
+      Inference::Coordinate{0, 0, 1.0},
+      Inference::Coordinate{0, 0, 1.0},
+  };
+
+  PostProcessing::ProcessedResults output = post_proc.run(dummy_input);
+
+  // Check shoulder mean works
+  float x = mean_of_coords_x(dummy_input.body_parts[left_shoulder],
+                             dummy_input.body_parts[right_shoulder]);
+  float y = mean_of_coords_y(dummy_input.body_parts[left_shoulder],
+                             dummy_input.body_parts[right_shoulder]);
+  BOOST_CHECK_CLOSE(x, output.body_parts[Shoulder].x, 0.1);
+  BOOST_CHECK_CLOSE(y, output.body_parts[Shoulder].y, 0.1);
+
+  // Check hip mean works
+  x = mean_of_coords_x(dummy_input.body_parts[left_hip],
+                       dummy_input.body_parts[right_hip]);
+  x = (dummy_input.body_parts[pelvis].x + x) / 2;
+  y = mean_of_coords_y(dummy_input.body_parts[left_hip],
+                       dummy_input.body_parts[right_hip]);
+  y = (dummy_input.body_parts[pelvis].y + y) / 2;
+  BOOST_CHECK_CLOSE(x, output.body_parts[Hip].x, 0.1);
+  BOOST_CHECK_CLOSE(y, output.body_parts[Hip].y, 0.1);
 }

--- a/test/test_post_processor.cpp
+++ b/test/test_post_processor.cpp
@@ -161,3 +161,44 @@ BOOST_AUTO_TEST_CASE(AverageCoordinatesWhenBothTrustworthy) {
   BOOST_CHECK_CLOSE(x, output.body_parts[Hip].x, 0.1);
   BOOST_CHECK_CLOSE(y, output.body_parts[Hip].y, 0.1);
 }
+
+BOOST_AUTO_TEST_CASE(DontAverageCoordinatesWhenNotBothTrustworthy) {
+  IIR::SmoothingSettings settings =
+      IIR::SmoothingSettings{std::vector<std::vector<float>>{}};
+  PostProcessing::PostProcessor post_proc =
+      PostProcessing::PostProcessor(0.0, settings);
+
+  Inference::InferenceResults dummy_input;
+  dummy_input.body_parts = {
+      Inference::Coordinate{0, 0, 1.0},
+      Inference::Coordinate{0, 0, 1.0},
+      Inference::Coordinate{0, 0, 1.0},  // Right shoulder
+      Inference::Coordinate{0, 0, 1.0},
+      Inference::Coordinate{0, 0, 1.0},
+      Inference::Coordinate{0, 0, 1.0},
+      Inference::Coordinate{1, 1, 0.0},  // Left shoulder
+      Inference::Coordinate{0, 0, 1.0},
+      Inference::Coordinate{0, 0, 1.0},
+      Inference::Coordinate{0, 0, 0.0},  // Pelvis
+      Inference::Coordinate{0, 0, 0.0},  // Right hip
+      Inference::Coordinate{0, 0, 1.0},
+      Inference::Coordinate{0, 0, 1.0},
+      Inference::Coordinate{0.5, 0.5, 1.0},  // Left hip
+      Inference::Coordinate{0, 0, 1.0},
+      Inference::Coordinate{0, 0, 1.0},
+  };
+
+  PostProcessing::ProcessedResults output = post_proc.run(dummy_input);
+
+  // Check shoulder mean works
+  BOOST_CHECK_CLOSE(dummy_input.body_parts[right_shoulder].x,
+                    output.body_parts[Shoulder].x, 0.1);
+  BOOST_CHECK_CLOSE(dummy_input.body_parts[right_shoulder].y,
+                    output.body_parts[Shoulder].y, 0.1);
+
+  // Check hip mean works
+  BOOST_CHECK_CLOSE(dummy_input.body_parts[left_hip].x,
+                    output.body_parts[Hip].x, 0.1);
+  BOOST_CHECK_CLOSE(dummy_input.body_parts[left_hip].y,
+                    output.body_parts[Hip].y, 0.1);
+}


### PR DESCRIPTION
This changes the interface from the post processor to include averaging between certain nodes

# Details

- Post processor now outputs a shorter array of `Joint`s
- Body parts that have a left and right version now get averaged depending on their `Trustworthy`ness

# Checklist

## Code
- [x] I have added some tests
- [x] I have run the tests locally to ensure they all pass by running `./test.sh`

## Documentation
- [x] I have updated comments

Closes #64 
