### PR TITLE
Overlay lines for posture

### DIFF
--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -154,6 +154,8 @@ GUI::MainWindow::~MainWindow() { delete mainLayout; }
 void GUI::MainWindow::initalFrame() {
   QLabel *frame = new QLabel();
   cv::Mat img = cv::imread("src/gui/posture-logo.png");
+  // Switch from BGR to RGB
+  cv::cvtColor(img, img, cv::COLOR_BGR2RGB);
   QImage imgIn = QImage((uchar *)  // NOLINT [readability/casting]
                         img.data,
                         img.cols, img.rows, img.step, QImage::Format_RGB888);

--- a/src/gui/mainwindow.h
+++ b/src/gui/mainwindow.h
@@ -38,6 +38,7 @@
 #include <QWidget>
 #include <QtCore/QVariant>
 #include <opencv2/imgcodecs.hpp>
+#include "opencv2/opencv.hpp"
 
 #include "../intermediate_structures.h"
 #include "../posture_estimator.h"

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -46,7 +46,7 @@ int main(int argc, char* argv[]) {
   QApplication a(argc, argv);
   GUI::MainWindow w;
   QCoreApplication::processEvents();
-  w.showMaximized();
+  // w.showMaximized();
 
   main_window_ptr = &w;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -46,7 +46,7 @@ int main(int argc, char* argv[]) {
   QApplication a(argc, argv);
   GUI::MainWindow w;
   QCoreApplication::processEvents();
-  // w.showMaximized();
+  w.showMaximized();
 
   main_window_ptr = &w;
 

--- a/src/pipeline.cpp
+++ b/src/pipeline.cpp
@@ -110,7 +110,7 @@ void Pipeline::post_processing_thread_body() {
 
     overlay_image(pose_result, next_frame.raw_image);
 
-    //callback(pose_result, next_frame.raw_image);
+    callback(pose_result, next_frame.raw_image);
   }
 }
 
@@ -120,17 +120,18 @@ void Pipeline::overlay_image(PostureEstimating::PoseStatus pose_status, cv::Mat 
   int imageWidth = raw_image.cols;
   int imageHeight = raw_image.rows;
 
-  for (int i = JointMin + 1; i <= JointMax; i++) {
-    cv::Point upper(static_cast<int>(current.joints[i-1].coord.x * imageWidth), 
+  std::array<cv::Scalar, JointMax+1> colors = {cv::Scalar(0,255,0), cv::Scalar(255,0,0), cv::Scalar(0,0,255), cv::Scalar(255,255,0), cv::Scalar(0,255,255), cv::Scalar(255,0,255)};
+
+  for (int i = JointMin + 1; i <= JointMax-2; i++) {
+    if(current.joints[i].coord.status == PostProcessing::Trustworthy && current.joints[i-1].coord.status == PostProcessing::Trustworthy){
+      cv::Point upper(static_cast<int>(current.joints[i-1].coord.x * imageWidth), 
                     static_cast<int>(current.joints[i-1].coord.y * imageHeight));
 
-    cv::Point curr(static_cast<int>(current.joints[i].coord.x * imageWidth),
+      cv::Point curr(static_cast<int>(current.joints[i].coord.x * imageWidth),
                    static_cast<int>(current.joints[i].coord.y * imageHeight));
-    cv::line(raw_image, upper, curr, cv::Scalar(0,255,0), 5);    
-  }
-  
-  cv::imshow("Live", raw_image);
-  cv::waitKey(5);
+      cv::line(raw_image, upper, curr, colors.at(i), 5);
+    }
+  }  
 }
 
 Pipeline::Pipeline(uint8_t num_inference_core_threads,

--- a/src/pipeline.cpp
+++ b/src/pipeline.cpp
@@ -114,26 +114,27 @@ void Pipeline::post_processing_thread_body() {
   }
 }
 
-void Pipeline::overlay_image(PostureEstimating::PoseStatus pose_status, cv::Mat raw_image){
+void Pipeline::overlay_image(PostureEstimating::PoseStatus pose_status,
+                             cv::Mat raw_image) {
   PostureEstimating::Pose current = pose_status.current_pose;
 
   int imageWidth = raw_image.cols;
   int imageHeight = raw_image.rows;
 
-  std::array<cv::Scalar, JointMax+1> colors = {cv::Scalar(0,255,0), cv::Scalar(255,0,0), cv::Scalar(0,0,255), cv::Scalar(255,255,0), cv::Scalar(0,255,255), cv::Scalar(255,0,255)};
-
   cv::cvtColor(raw_image, raw_image, cv::COLOR_BGR2RGB);
 
-  for (int i = JointMin + 1; i <= JointMax-2; i++) {
-    if(current.joints[i].coord.status == PostProcessing::Trustworthy && current.joints[i-1].coord.status == PostProcessing::Trustworthy){
-      cv::Point upper(static_cast<int>(current.joints[i-1].coord.x * imageWidth), 
-                    static_cast<int>(current.joints[i-1].coord.y * imageHeight));
+  for (int i = JointMin + 1; i <= JointMax - 2; i++) {
+    if (current.joints[i].coord.status == PostProcessing::Trustworthy &&
+        current.joints[i - 1].coord.status == PostProcessing::Trustworthy) {
+      cv::Point upper(
+          static_cast<int>(current.joints[i - 1].coord.x * imageWidth),
+          static_cast<int>(current.joints[i - 1].coord.y * imageHeight));
 
       cv::Point curr(static_cast<int>(current.joints[i].coord.x * imageWidth),
-                   static_cast<int>(current.joints[i].coord.y * imageHeight));
-      cv::line(raw_image, upper, curr, colors.at(i), 5);
+                     static_cast<int>(current.joints[i].coord.y * imageHeight));
+      cv::line(raw_image, upper, curr, colours.at(i), 5);
     }
-  }  
+  }
 }
 
 Pipeline::Pipeline(uint8_t num_inference_core_threads,
@@ -146,7 +147,6 @@ Pipeline::Pipeline(uint8_t num_inference_core_threads,
       frame_generator(&frame_delay),
       core_results(&this->running, num_inference_core_threads),
       callback(callback) {
-  
   if (num_inference_core_threads == 0) {
     throw std::invalid_argument("num_inference_core_threads must not be zero");
   }

--- a/src/pipeline.cpp
+++ b/src/pipeline.cpp
@@ -122,6 +122,8 @@ void Pipeline::overlay_image(PostureEstimating::PoseStatus pose_status, cv::Mat 
 
   std::array<cv::Scalar, JointMax+1> colors = {cv::Scalar(0,255,0), cv::Scalar(255,0,0), cv::Scalar(0,0,255), cv::Scalar(255,255,0), cv::Scalar(0,255,255), cv::Scalar(255,0,255)};
 
+  cv::cvtColor(raw_image, raw_image, cv::COLOR_BGR2RGB);
+
   for (int i = JointMin + 1; i <= JointMax-2; i++) {
     if(current.joints[i].coord.status == PostProcessing::Trustworthy && current.joints[i-1].coord.status == PostProcessing::Trustworthy){
       cv::Point upper(static_cast<int>(current.joints[i-1].coord.x * imageWidth), 

--- a/src/pipeline.h
+++ b/src/pipeline.h
@@ -369,6 +369,15 @@ struct CoreResults {
 class Pipeline {
  private:
   /**
+  * @brief Array of colours used to display lines between detected joints
+  *
+  */
+  std::array<cv::Scalar, JointMax + 1> colours = {
+        cv::Scalar(0, 255, 0),   cv::Scalar(255, 0, 0),
+        cv::Scalar(0, 0, 255),   cv::Scalar(255, 255, 0),
+        cv::Scalar(0, 255, 255), cv::Scalar(255, 0, 255)};
+
+  /**
    * @brief Vector of all threads created in the pipeline
    *
    * The de-constructor iterates through this and calls `join()` an each thread
@@ -424,10 +433,12 @@ class Pipeline {
   void (*callback)(PostureEstimating::PoseStatus, cv::Mat);
 
   /**
-   * @brief Function to overlay a stick figure of user posture over the input image      
+   * @brief Function to overlay a stick figure of user posture over the input
+   * image
    *
    */
-  void overlay_image(PostureEstimating::PoseStatus pose_status, cv::Mat raw_image);
+  void overlay_image(PostureEstimating::PoseStatus pose_status,
+                     cv::Mat raw_image);
 
  public:
   /**

--- a/src/pipeline.h
+++ b/src/pipeline.h
@@ -423,6 +423,12 @@ class Pipeline {
    */
   void (*callback)(PostureEstimating::PoseStatus, cv::Mat);
 
+  /**
+   * @brief Function to overlay a stick figure of user posture over the input image      
+   *
+   */
+  void overlay_image(PostureEstimating::PoseStatus pose_status, cv::Mat raw_image);
+
  public:
   /**
    * @brief Construct a new Pipeline object

--- a/src/pre_processor.cpp
+++ b/src/pre_processor.cpp
@@ -45,8 +45,8 @@ PreProcessedImage PreProcessor::run(cv::Mat cv_image) {
   cv::resize(cv_image, cv_image, cv::Size(model_width, model_height));
   uint8_t* resized_image = cv_image.data;
 
-  float* normalised_image =
-      reinterpret_cast<float*>(malloc(model_width * model_height * 3 * sizeof(float)));
+  float* normalised_image = reinterpret_cast<float*>(
+      malloc(model_width * model_height * 3 * sizeof(float)));
 
   normalise(resized_image, normalised_image);
 

--- a/src/pre_processor.cpp
+++ b/src/pre_processor.cpp
@@ -46,7 +46,7 @@ PreProcessedImage PreProcessor::run(cv::Mat cv_image) {
   uint8_t* resized_image = cv_image.data;
 
   float* normalised_image =
-      reinterpret_cast<float*>(malloc(224 * 224 * 3 * sizeof(float)));
+      reinterpret_cast<float*>(malloc(model_width * model_height * 3 * sizeof(float)));
 
   normalise(resized_image, normalised_image);
 


### PR DESCRIPTION
# Details

- Lines are now drawn between the detected Head, Neck, Shoulder and Hip
- We disregard the Knee and Feet point as they will likely be out of frame
- Switch BGR channels back to RGB

# Screenshots/Gif (if appropriate)

![overlayed-image](https://user-images.githubusercontent.com/45148261/112643989-d3f28380-8e3c-11eb-8bc5-5c56a805334a.png)


# Checklist

## Code
- [ ] I have added some tests
- [x] I have run the tests locally to ensure they all pass by running `.scripts/build.sh -enable-testing`

## Documentation
- [ ] I have updated documentation appropriately (GitHub Pages)
- [ ] I have tested the updated GitHub Pages locally to ensure the changes to documentation render correctly (see this [Guidance](https://ese-peasy.github.io/PosturePerfection/guidance.html) page)

Closes #90 