### PR TITLE
Refactored Video Feed to use Signals and Slots

### DIFF
--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -98,6 +98,10 @@ GUI::MainWindow::MainWindow(Pipeline::Pipeline *pipeline, QWidget *parent)
   central->setLayout(mainLayout);
   setCentralWidget(central);
   setWindowTitle(tr("Posture Perfection"));
+
+  qRegisterMetaType<cv::Mat>("cv::Mat");
+  connect(this, SIGNAL(currentFrameSignal(cv::Mat)), this,
+          SLOT(updateVideoFrame(cv::Mat)));
 }
 
 void GUI::MainWindow::updatePose(PostureEstimating::PoseStatus poseStatus) {
@@ -246,7 +250,11 @@ void GUI::MainWindow::initalFrame() {
   mainPageLayout->addWidget(frame, 1, 0);
 }
 
-void GUI::MainWindow::updateFrame(cv::Mat currentFrame) {
+void GUI::MainWindow::emitNewFrame(cv::Mat currentFrame) {
+  emit currentFrameSignal(currentFrame);
+}
+
+void GUI::MainWindow::updateVideoFrame(cv::Mat currentFrame) {
   QImage imgIn = QImage((uchar *)  // NOLINT [readability/casting]
                         currentFrame.data,
                         currentFrame.cols, currentFrame.rows, currentFrame.step,

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -30,9 +30,9 @@
 GUI::MainWindow::MainWindow(Pipeline::Pipeline *pipeline, QWidget *parent)
     : QMainWindow(parent) {
   // Create the different GUI pages
+  pipelinePtr = pipeline;
   createMainPage();
   createSettingsPage(pipeline);
-  pipelinePtr = pipeline;
 
   // Stack the pages within the mainwindow
   QStackedWidget *stackedWidget = new QStackedWidget;
@@ -133,8 +133,11 @@ void GUI::MainWindow::createSettingsPage(Pipeline::Pipeline *pipeline) {
   confidenceLabel->setStyleSheet("QLabel {color : white; }");
   QSlider *slider = new QSlider(Qt::Horizontal, this);
   slider->setMinimum(0);
-  slider->setMaximum(10);
+  slider->setMaximum(100);
   slider->setTickInterval(1);
+  int initalThreshold =
+      static_cast<int>(pipelinePtr->get_confidence_threshold() * 100);
+  slider->setValue(initalThreshold);
   vertThreshold->setSpacing(0);
   vertThreshold->setMargin(0);
   vertThreshold->addWidget(confidenceLabel, 0, Qt::AlignBottom);
@@ -184,7 +187,7 @@ void GUI::MainWindow::setIdealPosture() {
 }
 
 void GUI::MainWindow::setThresholdValue(int scaledValue) {
-  float value = static_cast<float>(scaledValue) / 10.0;
+  float value = static_cast<float>(scaledValue) / 100.0;
   pipelinePtr->set_confidence_threshold(value);
 }
 

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -185,7 +185,7 @@ void GUI::MainWindow::setIdealPosture() {
 
 void GUI::MainWindow::setThresholdValue(int scaledValue) {
   float value = static_cast<float>(scaledValue) / 10.0;
-  pipelinePtr->set_confidence_threshold(scaledValue);
+  pipelinePtr->set_confidence_threshold(value);
 }
 
 void GUI::MainWindow::increaseVideoFramerate() {

--- a/src/gui/mainwindow.h
+++ b/src/gui/mainwindow.h
@@ -90,7 +90,7 @@ class MainWindow : public QMainWindow {
    *
    * @param currentFrame a `cv::Mat` object
    */
-  void updateFrame(cv::Mat currentFrame);
+  void emitNewFrame(cv::Mat currentFrame);
 
   /**
    * @brief Creates the main page within the application
@@ -141,7 +141,18 @@ class MainWindow : public QMainWindow {
    */
   void setIdealPosture();
 
+  /**
+   * @brief update the video ouput once a new frame has been captured
+   *
+   */
+  void updateVideoFrame(cv::Mat currentFrame);
+
  signals:
+  /**
+   * @brief emit the newly captured frame
+   *
+   */
+  void currentFrameSignal(cv::Mat currentFrame);
 
  private:
   /**

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -38,7 +38,7 @@ Pipeline::Pipeline* pipeline_ptr;
 void frame_callback(PostureEstimating::PoseStatus pose_status,
                     cv::Mat input_image) {
   main_window_ptr->updatePose(pose_status);
-  main_window_ptr->updateFrame(input_image);
+  main_window_ptr->emitNewFrame(input_image);
 }
 
 int main(int argc, char* argv[]) {

--- a/src/pipeline.cpp
+++ b/src/pipeline.cpp
@@ -179,6 +179,10 @@ bool Pipeline::set_confidence_threshold(float threshold) {
   return post_processor.set_confidence_threshold(threshold);
 }
 
+float Pipeline::get_confidence_threshold() {
+  return post_processor.get_confidence_threshold();
+}
+
 float Pipeline::increase_framerate(void) {
   // Increasing frame rate means decreasing frame delay
   auto new_frame_delay = frame_delay >> 1;

--- a/src/pipeline.h
+++ b/src/pipeline.h
@@ -471,6 +471,13 @@ class Pipeline {
   bool set_confidence_threshold(float threshold);
 
   /**
+   * @brief Get the confidence threshold object
+   * 
+   * @return `float` Currently set confidence threshold
+   */
+  float get_confidence_threshold();
+
+  /**
    * @brief Increment the frame rate to the next predefined value
    *
    * If the maximum frame rate of the system is reached, it will not be

--- a/src/post_processor.cpp
+++ b/src/post_processor.cpp
@@ -149,4 +149,8 @@ bool PostProcessor::set_confidence_threshold(float confidence_threshold) {
   }
 }
 
+float PostProcessor::get_confidence_threshold() {
+  return confidence_threshold;
+}
+
 }  // namespace PostProcessing

--- a/src/post_processor.h
+++ b/src/post_processor.h
@@ -83,6 +83,13 @@ class PostProcessor {
    * @return `false` If the new threshold value is invalid
    */
   bool set_confidence_threshold(float confidence_threshold);
+
+  /**
+   * @brief Get the confidence threshold object
+   *
+   * @return `float` Currently set confidence threshold
+   */
+  float get_confidence_threshold();
 };
 
 }  // namespace PostProcessing


### PR DESCRIPTION
# Details

- Updated the main window to emit the newly captured frame as a signal.
- Created a public slot to use the newly captured frame as the new video output. 
- Fixed a basic bug regarding the confidence threshold outlined in issue 110.



# Checklist

## Code
- [ ] I have added some tests
- [x] I have run the tests locally to ensure they all pass by running `.scripts/build.sh -enable-testing`

## Documentation
- [ ] I have updated documentation appropriately (GitHub Pages)
- [ ] I have tested the updated GitHub Pages locally to ensure the changes to documentation render correctly (see this [Guidance](https://ese-peasy.github.io/PosturePerfection/guidance.html) page)

Closes #97 
Closes #110 
