### PR TITLE
Smoothing

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -23,6 +23,7 @@ set(NTFYSRC
 set(LIBSRC
   iir.cpp
   inference_core.cpp
+  framerate_settings.cpp
   post_processor.cpp
   pre_processor.cpp
   posture_estimator.cpp

--- a/src/framerate_settings.cpp
+++ b/src/framerate_settings.cpp
@@ -1,3 +1,21 @@
+/**
+ * @copyright Copyright (C) 2021  Miklas Riechmann
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
 #include "pipeline.h"
 #define DEFAULT_FRAMERATE_SETTING 1
 
@@ -6,13 +24,13 @@ FramerateSettings::FramerateSettings(Pipeline* pipeline)
     : framerate_settings(
           {FramerateSetting{
                IIR::SmoothingSettings{std::vector<std::vector<float>>{
-                   {{0.03168934, 0.06337869, 0.03168934, 1., -0.41421356, 0.},
-                    {1., 1., 0., 1., -1.0448155, 0.47759225}}}},
+                   {{0.20657208, 0.41314417, 0.20657208, 1., -0.36952738,
+                     0.19581571}}}},
                1000},
            FramerateSetting{
                IIR::SmoothingSettings{std::vector<std::vector<float>>{
-                   {{0.03168934, 0.06337869, 0.03168934, 1., -0.41421356, 0.},
-                    {1., 1., 0., 1., -1.0448155, 0.47759225}}}},
+                   {{0.10853539, 0.21707078, 0.10853539, 1., -0.87674856,
+                     0.31089012}}}},
                667},
            FramerateSetting{
                IIR::SmoothingSettings{std::vector<std::vector<float>>{
@@ -21,28 +39,38 @@ FramerateSettings::FramerateSettings(Pipeline* pipeline)
                500},
            FramerateSetting{
                IIR::SmoothingSettings{std::vector<std::vector<float>>{
-                   {{0.03168934, 0.06337869, 0.03168934, 1., -0.41421356, 0.},
-                    {1., 1., 0., 1., -1.0448155, 0.47759225}}}},
+                   {{4.15080543e-04, 8.30161086e-04, 4.15080543e-04,
+                     1.00000000e+00, -1.48014304e+00, 5.56155720e-01},
+                    {1.00000000e+00, 2.00000000e+00, 1.00000000e+00,
+                     1.00000000e+00, -1.70131184e+00, 7.88682638e-01}}}},
                333},
            FramerateSetting{
                IIR::SmoothingSettings{std::vector<std::vector<float>>{
-                   {{0.03168934, 0.06337869, 0.03168934, 1., -0.41421356, 0.},
-                    {1., 1., 0., 1., -1.0448155, 0.47759225}}}},
+                   {{1.44120224e-04, 2.88240448e-04, 1.44120224e-04,
+                     1.00000000e+00, -1.59971967e+00, 6.45176015e-01},
+                    {1.00000000e+00, 2.00000000e+00, 1.00000000e+00,
+                     1.00000000e+00, -1.78525306e+00, 8.35981369e-01}}}},
                250},
            FramerateSetting{
                IIR::SmoothingSettings{std::vector<std::vector<float>>{
-                   {{0.03168934, 0.06337869, 0.03168934, 1., -0.41421356, 0.},
-                    {1., 1., 0., 1., -1.0448155, 0.47759225}}}},
+                   {{1.03686193e-05, 2.07372385e-05, 1.03686193e-05,
+                     1.00000000e+00, -1.79158770e+00, 8.04092844e-01},
+                    {1.00000000e+00, 2.00000000e+00, 1.00000000e+00,
+                     1.00000000e+00, -1.90064656e+00, 9.13912934e-01}}}},
                125},
            FramerateSetting{
                IIR::SmoothingSettings{std::vector<std::vector<float>>{
-                   {{0.03168934, 0.06337869, 0.03168934, 1., -0.41421356, 0.},
-                    {1., 1., 0., 1., -1.0448155, 0.47759225}}}},
+                   {{3.73142259e-06, 7.46284518e-06, 3.73142259e-06,
+                     1.00000000e+00, -1.83835927e+00, 8.45909649e-01},
+                    {1.00000000e+00, 2.00000000e+00, 1.00000000e+00,
+                     1.00000000e+00, -1.92524967e+00, 9.33156924e-01}}}},
                80},
            FramerateSetting{
                IIR::SmoothingSettings{std::vector<std::vector<float>>{
-                   {{0.03168934, 0.06337869, 0.03168934, 1., -0.41421356, 0.},
-                    {1., 1., 0., 1., -1.0448155, 0.47759225}}}},
+                   {{5.94209980e-07, 1.18841996e-06, 5.94209980e-07,
+                     1.00000000e+00, -1.89771159e+00, 9.00749843e-01},
+                    {1.00000000e+00, 2.00000000e+00, 1.00000000e+00,
+                     1.00000000e+00, -1.95452916e+00, 9.57658381e-01}}}},
                50}}),
       current_setting(DEFAULT_FRAMERATE_SETTING),
       pipeline(pipeline) {}

--- a/src/framerate_settings.cpp
+++ b/src/framerate_settings.cpp
@@ -1,0 +1,72 @@
+#include "pipeline.h"
+#define DEFAULT_FRAMERATE_SETTING 1
+
+namespace Pipeline {
+FramerateSettings::FramerateSettings(Pipeline* pipeline)
+    : framerate_settings(
+          {FramerateSetting{
+               IIR::SmoothingSettings{std::vector<std::vector<float>>{
+                   {{0.03168934, 0.06337869, 0.03168934, 1., -0.41421356, 0.},
+                    {1., 1., 0., 1., -1.0448155, 0.47759225}}}},
+               1000},
+           FramerateSetting{
+               IIR::SmoothingSettings{std::vector<std::vector<float>>{
+                   {{0.03168934, 0.06337869, 0.03168934, 1., -0.41421356, 0.},
+                    {1., 1., 0., 1., -1.0448155, 0.47759225}}}},
+               667},
+           FramerateSetting{
+               IIR::SmoothingSettings{std::vector<std::vector<float>>{
+                   {{0.03168934, 0.06337869, 0.03168934, 1., -0.41421356, 0.},
+                    {1., 1., 0., 1., -1.0448155, 0.47759225}}}},
+               500},
+           FramerateSetting{
+               IIR::SmoothingSettings{std::vector<std::vector<float>>{
+                   {{0.03168934, 0.06337869, 0.03168934, 1., -0.41421356, 0.},
+                    {1., 1., 0., 1., -1.0448155, 0.47759225}}}},
+               333},
+           FramerateSetting{
+               IIR::SmoothingSettings{std::vector<std::vector<float>>{
+                   {{0.03168934, 0.06337869, 0.03168934, 1., -0.41421356, 0.},
+                    {1., 1., 0., 1., -1.0448155, 0.47759225}}}},
+               250},
+           FramerateSetting{
+               IIR::SmoothingSettings{std::vector<std::vector<float>>{
+                   {{0.03168934, 0.06337869, 0.03168934, 1., -0.41421356, 0.},
+                    {1., 1., 0., 1., -1.0448155, 0.47759225}}}},
+               125},
+           FramerateSetting{
+               IIR::SmoothingSettings{std::vector<std::vector<float>>{
+                   {{0.03168934, 0.06337869, 0.03168934, 1., -0.41421356, 0.},
+                    {1., 1., 0., 1., -1.0448155, 0.47759225}}}},
+               80},
+           FramerateSetting{
+               IIR::SmoothingSettings{std::vector<std::vector<float>>{
+                   {{0.03168934, 0.06337869, 0.03168934, 1., -0.41421356, 0.},
+                    {1., 1., 0., 1., -1.0448155, 0.47759225}}}},
+               50}}),
+      current_setting(DEFAULT_FRAMERATE_SETTING),
+      pipeline(pipeline) {}
+
+void FramerateSettings::notify_pipeline(void) {
+  pipeline->updated_framerate(framerate_settings.at(current_setting));
+}
+
+FramerateSetting FramerateSettings::get_framerate_setting(void) {
+  return framerate_settings.at(current_setting);
+}
+
+void FramerateSettings::decrease_framerate(void) {
+  if (current_setting > 0) {
+    current_setting--;
+    notify_pipeline();
+  }
+}
+
+void FramerateSettings::increase_framerate(void) {
+  if (current_setting < framerate_settings.size() - 1) {
+    current_setting++;
+    notify_pipeline();
+  }
+}
+
+}  // namespace Pipeline

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -159,7 +159,8 @@ void GUI::MainWindow::createSettingsPage() {
   connect(downFramerate, SIGNAL(clicked()), this,
           SLOT(decreaseVideoFramerate()));
 
-  currentFrame->setText("Frame Rate: 1 fps");
+  setOutputFramerate();
+
   currentFrame->setStyleSheet("QLabel {color : white; }");
   framerate->addWidget(currentFrame, 1, 1, 1, 1, Qt::AlignLeft);
 
@@ -196,7 +197,8 @@ void GUI::MainWindow::increaseVideoFramerate() {
 
 void GUI::MainWindow::setOutputFramerate() {
   float newFramerate = pipelinePtr->get_framerate();
-  QString output = "Frame Rate: " + QString::number(newFramerate) + " fps";
+  QString output =
+      "Frame Rate: " + QString::number(newFramerate, 'f', 1) + " fps";
   currentFrame->setText(output);
 }
 

--- a/src/iir.cpp
+++ b/src/iir.cpp
@@ -34,6 +34,11 @@ IIR2ndOrderFilter::IIR2ndOrderFilter(std::vector<float> coefficients) {
   };
 }
 
+void IIR2ndOrderFilter::set(float x) {
+  nodes.tap1 = x;
+  nodes.tap2 = x;
+}
+
 float IIR2ndOrderFilter::run(float x) {
   float output = this->nodes.b1 * this->nodes.tap1;
   x = x - (this->nodes.a1 * this->nodes.tap1);
@@ -48,6 +53,12 @@ float IIR2ndOrderFilter::run(float x) {
 IIRFilter::IIRFilter(SmoothingSettings smoothing_settings) {
   for (std::vector<float> cs : smoothing_settings.coefficients) {
     this->filters.push_back(IIR2ndOrderFilter(cs));
+  }
+}
+
+void IIRFilter::set(float x) {
+  for (auto& filter : filters) {
+    filter.set(x);
   }
 }
 

--- a/src/iir.h
+++ b/src/iir.h
@@ -79,13 +79,6 @@ class IIR2ndOrderFilter {
   explicit IIR2ndOrderFilter(std::vector<float> coefficients);
 
   /**
-   * @brief Set all data in the filter to the given value
-   *
-   * @param x `float` Value to overwrite filter content
-   */
-  void set(float x);
-
-  /**
    * @brief Apply the filter to the next data sample, `x`
    *
    * Every call to this method constitutes a time step in the IIR filter

--- a/src/iir.h
+++ b/src/iir.h
@@ -79,6 +79,13 @@ class IIR2ndOrderFilter {
   explicit IIR2ndOrderFilter(std::vector<float> coefficients);
 
   /**
+   * @brief Set all data in the filter to the given value
+   *
+   * @param x `float` Value to overwrite filter content
+   */
+  void set(float x);
+
+  /**
    * @brief Apply the filter to the next data sample, `x`
    *
    * Every call to this method constitutes a time step in the IIR filter
@@ -117,6 +124,13 @@ class IIRFilter {
    * containing the SOS coefficients for the IIR filter
    */
   explicit IIRFilter(SmoothingSettings smoothing_settings);
+
+  /**
+   * @brief Set all data in the filter to the given value
+   *
+   * @param x `float` Value to overwrite filter content
+   */
+  void set(float x);
 
   /**
    * @brief Apply the filter to the next data sample, `x`

--- a/src/pipeline.cpp
+++ b/src/pipeline.cpp
@@ -147,8 +147,8 @@ Pipeline::Pipeline(uint8_t num_inference_core_threads,
       // Disable smoothing with empty settings
       post_processor(
           0.1, IIR::SmoothingSettings{std::vector<std::vector<float>>{
-                   {{0.00289819, 0.00579639, 0.00289819, 1., -0.72654253, 0.},
-                    {1., 1., 0., 1., -1.64755222, 0.73233892}}}}),
+                   {{0.03168934, 0.06337869, 0.03168934, 1., -0.41421356, 0.},
+                    {1., 1., 0., 1., -1.0448155, 0.47759225}}}}),
       posture_estimator(),
       frame_generator(&frame_delay),
       core_results(&this->running, num_inference_core_threads),

--- a/src/pipeline.cpp
+++ b/src/pipeline.cpp
@@ -24,6 +24,7 @@
 
 #define MODEL_INPUT_X 224
 #define MODEL_INPUT_Y 224
+#define CONFIDENCE_THRESH_DEFAULT 0.1
 
 namespace Pipeline {
 
@@ -152,7 +153,8 @@ Pipeline::Pipeline(uint8_t num_inference_core_threads,
       preprocessor(MODEL_INPUT_X, MODEL_INPUT_Y),
       // Disable smoothing with empty settings
       post_processor(
-          0.1, framerate_settings.get_framerate_setting().smoothing_settings),
+          CONFIDENCE_THRESH_DEFAULT,
+          framerate_settings.get_framerate_setting().smoothing_settings),
       posture_estimator(),
       frame_generator(&framerate_settings),
       core_results(&this->running, num_inference_core_threads),

--- a/src/pipeline.cpp
+++ b/src/pipeline.cpp
@@ -145,8 +145,10 @@ Pipeline::Pipeline(uint8_t num_inference_core_threads,
                    void (*callback)(PostureEstimating::PoseStatus, cv::Mat))
     : preprocessor(MODEL_INPUT_X, MODEL_INPUT_Y),
       // Disable smoothing with empty settings
-      post_processor(0.1,
-                     IIR::SmoothingSettings{std::vector<std::vector<float>>{}}),
+      post_processor(
+          0.1, IIR::SmoothingSettings{std::vector<std::vector<float>>{
+                   {{0.00289819, 0.00579639, 0.00289819, 1., -0.72654253, 0.},
+                    {1., 1., 0., 1., -1.64755222, 0.73233892}}}}),
       posture_estimator(),
       frame_generator(&frame_delay),
       core_results(&this->running, num_inference_core_threads),

--- a/src/pipeline.h
+++ b/src/pipeline.h
@@ -237,27 +237,82 @@ class Buffer {
  */
 namespace Pipeline {
 
+/**
+ * @brief Parameters relevant to the currently set frame rate
+ *
+ */
 struct FramerateSetting {
-  IIR::SmoothingSettings smoothing_settings;
-  size_t frame_delay;
+  IIR::SmoothingSettings
+      smoothing_settings;  ///< Smoothing settings (coefficients) for the IIR
+                           ///< filter
+  size_t frame_delay;  ///< Delay in ms that represents the current frame rate
 };
 
+// Forward declaration of `Pipeline` for use in `FramerateSettings`
 class Pipeline;
 
+/**
+ * @brief Class to maintain the currently set frame rate and any related
+ * settings
+ */
 class FramerateSettings {
  private:
-  // **MUST** be defined in order of ascending frame rate, i.e., descending
-  // frame delay
+  /**
+   * @brief Structure containing presets for various frame rates
+   *
+   * Check `framerate_settings.cpp` for the possible presets and the default, in
+   * order of ascending frame rate
+   *
+   */
   std::vector<FramerateSetting> framerate_settings;
 
+  /**
+   * @brief Index indicating the current setting
+   *
+   */
   size_t current_setting;
+
+  /**
+   * @brief Pointer to the `Pipeline`
+   *
+   * Only `Pipeline::updated_framerate` is used as a callback to notify the
+   * pipeline of an updated frame rate.
+   *
+   */
   Pipeline* pipeline;
+
+  /**
+   * @brief Internal function that is called to notify relevant objects of a
+   * change in frame rate
+   *
+   */
   void notify_pipeline(void);
 
  public:
+  /**
+   * @brief Construct a new `FramerateSettings` object
+   *
+   * @param pipeline `Pipeline*` pointer to the pipeline
+   */
   FramerateSettings(Pipeline* pipeline);
+
+  /**
+   * @brief Get the currently set `FramerateSetting`
+   *
+   * @return `FramerateSetting`
+   */
   FramerateSetting get_framerate_setting(void);
+
+  /**
+   * @brief Increase the frame rate
+   *
+   */
   void increase_framerate(void);
+
+  /**
+   * @brief Decrease the frame rate
+   *
+   */
   void decrease_framerate(void);
 };
 
@@ -287,8 +342,6 @@ struct RawFrame {
   uint8_t id;         ///< Frame ordering ID
   cv::Mat raw_image;  ///< Raw `cv::Mat` (OpenCV) image
 };
-
-struct FramerateSetting;
 
 class FrameGenerator {
  private:

--- a/src/pipeline.h
+++ b/src/pipeline.h
@@ -294,7 +294,7 @@ class FramerateSettings {
    *
    * @param pipeline `Pipeline*` pointer to the pipeline
    */
-  FramerateSettings(Pipeline* pipeline);
+  explicit FramerateSettings(Pipeline* pipeline);
 
   /**
    * @brief Get the currently set `FramerateSetting`

--- a/src/post_processor.cpp
+++ b/src/post_processor.cpp
@@ -23,6 +23,7 @@
 
 #define MIN_CONF_THRESH 0.0  // Minimum value a confidence threshold can be
 #define MAX_CONF_THRESH 1.0  // Maximum value a confidence threshold can be
+#define NUM_FILTERS_PER_BODY_PART 3  // No. IIR filters for each body part
 
 /**
  * @brief Take the mean of two body parts
@@ -63,10 +64,11 @@ namespace PostProcessing {
 
 PostProcessor::PostProcessor(float confidence_threshold,
                              IIR::SmoothingSettings smoothing_settings)
-    : confidence_threshold(confidence_threshold) {
+    : confidence_threshold(confidence_threshold),
+      smoothed_trustworthiness(smoothing_settings) {
   // Initialise filters for x and y component of each body part position
   // It may be interesting to add a third filter for confidence in time
-  for (int i = 0; i < (BodyPartMax + 1) * 2; i++) {
+  for (int i = 0; i < (BodyPartMax + 1) * NUM_FILTERS_PER_BODY_PART; i++) {
     this->iir_filters.push_back(IIR::IIRFilter(smoothing_settings));
   }
 }
@@ -88,14 +90,16 @@ ProcessedResults PostProcessor::run(
   Coordinate processed_body_part;
 
   for (; body_part_index < BodyPartMax + 1;
-       body_part_index++, filter_index += 2) {
+       body_part_index++, filter_index += NUM_FILTERS_PER_BODY_PART) {
     body_part = inference_core_output.body_parts.at(body_part_index);
 
     // Filter the incoming position for each body part
     // The incoming results structure is passed by value so it won't be
     // overwritten here
-    body_part.x = this->iir_filters.at(filter_index).run(body_part.x);
-    body_part.y = this->iir_filters.at(filter_index + 1).run(body_part.y);
+    body_part.x = iir_filters.at(filter_index).run(body_part.x);
+    body_part.y = iir_filters.at(filter_index + 1).run(body_part.y);
+    body_part.confidence =
+        iir_filters.at(filter_index + 2).run(body_part.confidence);
 
     processed_body_part =
         Coordinate{body_part.x, body_part.y,

--- a/src/post_processor.cpp
+++ b/src/post_processor.cpp
@@ -75,6 +75,25 @@ PostProcessor::PostProcessor(float confidence_threshold,
 
 ProcessedResults PostProcessor::run(
     Inference::InferenceResults inference_core_output) {
+  // Set the filters up for the very first frame
+  if (first_run) {
+    first_run = false;
+    printf("first run\n");
+    int body_part_index = BodyPartMin;
+    int filter_index = 0;
+    Inference::Coordinate body_part;
+
+    for (; body_part_index < BodyPartMax + 1;
+         body_part_index++, filter_index += NUM_FILTERS_PER_BODY_PART) {
+      body_part = inference_core_output.body_parts.at(body_part_index);
+
+      iir_filters.at(filter_index).set(body_part.x);
+      iir_filters.at(filter_index + 1).set(body_part.y);
+
+      iir_filters.at(filter_index + 2).set(body_part.confidence);
+    }
+  }
+
   // Initialise structure for results
   std::array<Coordinate, BodyPartMax + 1> intermediate_results;
   ProcessedResults results;
@@ -153,8 +172,6 @@ bool PostProcessor::set_confidence_threshold(float confidence_threshold) {
   }
 }
 
-float PostProcessor::get_confidence_threshold() {
-  return confidence_threshold;
-}
+float PostProcessor::get_confidence_threshold() { return confidence_threshold; }
 
 }  // namespace PostProcessing

--- a/src/post_processor.cpp
+++ b/src/post_processor.cpp
@@ -78,7 +78,6 @@ ProcessedResults PostProcessor::run(
   // Set the filters up for the very first frame
   if (first_run) {
     first_run = false;
-    printf("first run\n");
     int body_part_index = BodyPartMin;
     int filter_index = 0;
     Inference::Coordinate body_part;

--- a/src/post_processor.h
+++ b/src/post_processor.h
@@ -53,6 +53,7 @@ class PostProcessor {
   float confidence_threshold;
   std::vector<IIR::IIRFilter> iir_filters;
   IIR::IIRFilter smoothed_trustworthiness;
+  bool first_run = true;
 
  public:
   /**

--- a/src/post_processor.h
+++ b/src/post_processor.h
@@ -52,6 +52,7 @@ class PostProcessor {
  private:
   float confidence_threshold;
   std::vector<IIR::IIRFilter> iir_filters;
+  IIR::IIRFilter smoothed_trustworthiness;
 
  public:
   /**


### PR DESCRIPTION
# Details

- Rework IIR code to set the filters to the first frame received, i.e., not staring from a zero initial state anymore
- Create `FramerateSettings` class to allow easier changing of the frame rate and any associated parameters like IIR smoothing coefficients
- Make GUI display actual set frame rate on start instead of a placeholder value

# Checklist

## Code
- [ ] ~I have added some tests~
- [x] I have manually tested the additions
- [x] I have run the tests locally to ensure they all pass by running `.scripts/build.sh -enable-testing`

## Documentation
- [x] I have updated documentation appropriately (Doxygen)
- [ ] I have tested the updated GitHub Pages locally to ensure the changes to documentation render correctly (see this [Guidance](https://ese-peasy.github.io/PosturePerfection/guidance.html) page)

Closes #94 
