### PR TITLE
Posture correction functionality

### DIFF
--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -58,7 +58,6 @@ GUI::MainWindow::MainWindow(Pipeline::Pipeline *pipeline, QWidget *parent)
   framerate->addWidget(idealPosture, 1, 3, 1, 1, Qt::AlignCenter);
   connect(idealPosture, SIGNAL(clicked()), this, SLOT(setIdealPosture()));
 
-
   idealPosture->setStyleSheet(
       "background-color:rgb(10, 187, 228); border: none;");
 
@@ -132,23 +131,43 @@ void GUI::MainWindow::createSettingsPage() {
   QLabel *confidenceLabel = new QLabel();
   confidenceLabel->setText("Posture Estimating Sensitivity");
   confidenceLabel->setStyleSheet("QLabel {color : white; }");
-  QSlider *slider = new QSlider(Qt::Horizontal, this);
-  slider->setMinimum(0);
-  slider->setMaximum(100);
-  slider->setTickInterval(1);
+  QSlider *confidenceSlider = new QSlider(Qt::Horizontal, this);
+  confidenceSlider->setMinimum(0);
+  confidenceSlider->setMaximum(100);
+  confidenceSlider->setTickInterval(1);
   int initalThreshold =
       static_cast<int>(pipelinePtr->get_confidence_threshold() * 100);
-  slider->setValue(initalThreshold);
+  confidenceSlider->setValue(initalThreshold);
   vertThreshold->setSpacing(0);
   vertThreshold->setMargin(0);
   vertThreshold->addWidget(confidenceLabel, 0, Qt::AlignBottom);
-  vertThreshold->addWidget(slider, 0, Qt::AlignTop);
+  vertThreshold->addWidget(confidenceSlider, 0, Qt::AlignTop);
+
+  settingsPageLayout->addWidget(groupThreshold, 1, 0);
+
+  connect(confidenceSlider, SIGNAL(valueChanged(int)), this,
+          SLOT(setThresholdValue(int)));
+
+  // Allow user to select the pose change threshold
+  QLabel *poseChangeThresholdLabel = new QLabel();
+  poseChangeThresholdLabel->setText("Pose Change Threshold");
+  poseChangeThresholdLabel->setStyleSheet("QLabel {color : white; }");
+
+  QSlider *poseChangeThresholdSlider = new QSlider(Qt::Horizontal, this);
+  poseChangeThresholdSlider->setMinimum(0);
+  poseChangeThresholdSlider->setMaximum(5);
+  poseChangeThresholdSlider->setTickInterval(1);
+  int initalPoseChangeThreshold =
+      static_cast<int>(pipelinePtr->get_pose_change_threshold() * 10);
+  poseChangeThresholdSlider->setValue(initalPoseChangeThreshold);
+  vertThreshold->addWidget(poseChangeThresholdLabel, 0, Qt::AlignBottom);
+  vertThreshold->addWidget(poseChangeThresholdSlider, 0, Qt::AlignTop);
   groupThreshold->setLayout(vertThreshold);
 
   settingsPageLayout->addWidget(groupThreshold, 1, 0);
 
-  connect(slider, SIGNAL(valueChanged(int)), this,
-          SLOT(setThresholdValue(int)));
+  connect(poseChangeThresholdSlider, SIGNAL(valueChanged(int)), this,
+          SLOT(setPoseChangeThresholdValue(int)));
 
   // Let user adjust the video framerate
   framerate->setSpacing(0);
@@ -166,16 +185,6 @@ void GUI::MainWindow::createSettingsPage() {
 
   currentFrame->setStyleSheet("QLabel {color : white; }");
   framerate->addWidget(currentFrame, 1, 1, 1, 1, Qt::AlignLeft);
-
-  // Let the user take their current posture as the ideal posture
-  QLabel *idealLabel = new QLabel();
-  idealLabel->setText("Set Ideal Posture ->");
-  idealLabel->setStyleSheet("QLabel {color : white; }");
-  framerate->addWidget(idealLabel, 1, 2, 1, 1, Qt::AlignRight);
-
-  QPushButton *idealPosture = new QPushButton("&Ideal Posture");
-  framerate->addWidget(idealPosture, 1, 3, 1, 1, Qt::AlignCenter);
-  connect(idealPosture, SIGNAL(clicked()), this, SLOT(setIdealPosture()));
 
   QGroupBox *groupFramerate = new QGroupBox();
   groupFramerate->setLayout(framerate);
@@ -208,6 +217,11 @@ void GUI::MainWindow::setOutputFramerate() {
 void GUI::MainWindow::decreaseVideoFramerate() {
   pipelinePtr->decrease_framerate();
   setOutputFramerate();
+}
+
+void GUI::MainWindow::setPoseChangeThresholdValue(int scaledValue) {
+  float value = static_cast<float>(scaledValue) / 10.0;
+  pipelinePtr->set_confidence_threshold(value);
 }
 
 void GUI::MainWindow::showDateTime() {

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -54,14 +54,17 @@ GUI::MainWindow::MainWindow(Pipeline::Pipeline *pipeline, QWidget *parent)
   central->setStyleSheet("background-color:#0d1117;");
 
   // create three buttons
-  QPushButton *resetButton = new QPushButton("&Reset Posture");
+  QPushButton *idealPosture = new QPushButton("&Ideal Posture");
+  framerate->addWidget(idealPosture, 1, 3, 1, 1, Qt::AlignCenter);
+  connect(idealPosture, SIGNAL(clicked()), this, SLOT(setIdealPosture()));
 
-  resetButton->setStyleSheet(
+
+  idealPosture->setStyleSheet(
       "background-color:rgb(10, 187, 228); border: none;");
 
   QVBoxLayout *buttonBox = new QVBoxLayout;
   buttonBox->addWidget(pageComboBox);
-  buttonBox->addWidget(resetButton);
+  buttonBox->addWidget(idealPosture);
   groupBoxButtons->setLayout(buttonBox);
 
   // Create a title

--- a/src/gui/mainwindow.h
+++ b/src/gui/mainwindow.h
@@ -122,6 +122,12 @@ class MainWindow : public QMainWindow {
   void setThresholdValue(int);
 
   /**
+   * @brief Updates the `PostureEstimating::pose_change_threshold` value
+   *
+   */
+  void setPoseChangeThresholdValue(int);
+
+  /**
    * @brief Increases the video frame rate
    *
    */

--- a/src/pipeline.cpp
+++ b/src/pipeline.cpp
@@ -255,4 +255,8 @@ bool Pipeline::set_pose_change_threshold(float threshold) {
   return posture_estimator.set_pose_change_threshold(threshold);
 }
 
+float Pipeline::get_pose_change_threshold() {
+  return posture_estimator.get_pose_change_threshold();
+}
+
 }  // namespace Pipeline

--- a/src/pipeline.cpp
+++ b/src/pipeline.cpp
@@ -147,12 +147,12 @@ void Pipeline::overlay_image(PostureEstimating::PoseStatus pose_status,
       cv::Point midpoint(static_cast<int>((upper.x + curr.x) / 2),
                          static_cast<int>((upper.y + curr.y) / 2));
 
-      if (pose_status.pose_changes.joints.at(i).upper_angle > 0) {
+      if (pose_status.pose_changes.joints.at(i).upper_angle > 0.1) {
         cv::Point tip(static_cast<int>(midpoint.x - 50),
                       static_cast<int>(midpoint.y));
 
         cv::arrowedLine(raw_image, midpoint, tip, colours.at(i), 2);
-      } else {
+      } else if (pose_status.pose_changes.joints.at(i).upper_angle < -0.1) {
         cv::Point tip(static_cast<int>(midpoint.x + 50),
                       static_cast<int>(midpoint.y));
 

--- a/src/pipeline.cpp
+++ b/src/pipeline.cpp
@@ -143,6 +143,21 @@ void Pipeline::overlay_image(PostureEstimating::PoseStatus pose_status,
       cv::Point curr(static_cast<int>(current.joints[i].coord.x * imageWidth),
                      static_cast<int>(current.joints[i].coord.y * imageHeight));
       cv::line(raw_image, upper, curr, colours.at(i), 5);
+
+      cv::Point midpoint(static_cast<int>((upper.x + curr.x) / 2),
+                         static_cast<int>((upper.y + curr.y) / 2));
+
+      if (pose_status.pose_changes.joints.at(i).upper_angle > 0) {
+        cv::Point tip(static_cast<int>(midpoint.x - 50),
+                      static_cast<int>(midpoint.y));
+
+        cv::arrowedLine(raw_image, midpoint, tip, colours.at(i), 2);
+      } else {
+        cv::Point tip(static_cast<int>(midpoint.x + 50),
+                      static_cast<int>(midpoint.y));
+
+        cv::arrowedLine(raw_image, midpoint, tip, colours.at(i), 2);
+      }
     }
   }
 }

--- a/src/pipeline.h
+++ b/src/pipeline.h
@@ -524,19 +524,6 @@ class Pipeline {
    */
   void (*callback)(PostureEstimating::PoseStatus, cv::Mat);
 
-  /**
-   * @brief Function to overlay a stick figure of user posture over the input
-   * image
-   *
-   * @param `PostureEstimating::PoseStatus` The pose status output for the
-   * current frame
-   * @param `cv::Mat` The raw image for the current frame
-   * @param `float` The angle threshold (in radians) above which a posture is
-   * determined to be bad
-   */
-  void overlay_image(PostureEstimating::PoseStatus pose_status,
-                     cv::Mat raw_image, float pose_change_threshold);
-
  public:
   void updated_framerate(FramerateSetting new_settings);
 

--- a/src/pipeline.h
+++ b/src/pipeline.h
@@ -629,6 +629,13 @@ class Pipeline {
    * @return `false` If updating the threshold did not succeed
    */
   bool set_pose_change_threshold(float threshold);
+
+  /**
+   * @brief Get the current pose change threshold
+   *
+   * @return `float` Currently set pose change threshold
+   */
+  float get_pose_change_threshold();
 };
 }  // namespace Pipeline
 #endif  // SRC_PIPELINE_H_

--- a/src/pipeline.h
+++ b/src/pipeline.h
@@ -30,7 +30,6 @@
 #include "iir.h"
 #include "inference_core.h"
 #include "opencv2/core.hpp"
-#include "opencv2/imgproc.hpp"
 #include "opencv2/videoio.hpp"
 #include "post_processor.h"
 #include "posture_estimator.h"
@@ -474,15 +473,6 @@ struct CoreResults {
  */
 class Pipeline {
  private:
-  /**
-   * @brief Array of colours used to display lines between detected joints
-   *
-   */
-  std::array<cv::Scalar, JointMax + 1> colours = {
-      cv::Scalar(0, 255, 0),   cv::Scalar(255, 0, 0),
-      cv::Scalar(0, 0, 255),   cv::Scalar(255, 255, 0),
-      cv::Scalar(0, 255, 255), cv::Scalar(255, 0, 255)};
-
   /**
    * @brief Vector of all threads created in the pipeline
    *

--- a/src/pipeline.h
+++ b/src/pipeline.h
@@ -538,9 +538,14 @@ class Pipeline {
    * @brief Function to overlay a stick figure of user posture over the input
    * image
    *
+   * @param `PostureEstimating::PoseStatus` The pose status output for the
+   * current frame
+   * @param `cv::Mat` The raw image for the current frame
+   * @param `float` The angle threshold (in radians) above which a posture is
+   * determined to be bad
    */
   void overlay_image(PostureEstimating::PoseStatus pose_status,
-                     cv::Mat raw_image);
+                     cv::Mat raw_image, float pose_change_threshold);
 
  public:
   void updated_framerate(FramerateSetting new_settings);
@@ -615,6 +620,15 @@ class Pipeline {
    * ideal posture
    */
   void set_ideal_posture(PostureEstimating::Pose pose);
+
+  /**
+   * @brief Set the pose change threshold
+   *
+   * @param threshold New threshold to set
+   * @return `true` If updating the threshold succeeded
+   * @return `false` If updating the threshold did not succeed
+   */
+  bool set_pose_change_threshold(float threshold);
 };
 }  // namespace Pipeline
 #endif  // SRC_PIPELINE_H_

--- a/src/posture_estimator.cpp
+++ b/src/posture_estimator.cpp
@@ -177,6 +177,10 @@ bool PostureEstimator::set_pose_change_threshold(float threshold) {
   return false;
 }
 
+float PostureEstimator::get_pose_change_threshold(void) {
+  return this->pose_change_threshold;
+}
+
 PoseStatus PostureEstimator::runEstimator(
     PostProcessing::ProcessedResults results) {
   this->updateCurrentPoseAndCheckPosture(results);

--- a/src/posture_estimator.cpp
+++ b/src/posture_estimator.cpp
@@ -148,7 +148,9 @@ void PostureEstimator::checkGoodPosture() {
       return;
     }
   }
-  this->posture_state = Good;
+  if (!this->posture_state == Unset) {
+    this->posture_state = Good;
+  }
 }
 
 void PostureEstimator::calculateChangesAndCheckPosture() {

--- a/src/posture_estimator.h
+++ b/src/posture_estimator.h
@@ -89,6 +89,7 @@ struct PoseStatus {
   Pose current_pose;
   Pose pose_changes;
   bool good_posture;
+  bool ideal_pose_set;
 };
 
 /**
@@ -198,6 +199,11 @@ class PostureEstimator {
   Pose ideal_pose;
 
   /**
+   * @brief The `ideal_pose` is unset until the user manually sets it
+   */
+  bool ideal_pose_set = false;
+
+  /**
    * @brief A representation of what changes are needed to get
    * back to ideal `Pose`.
    */
@@ -223,6 +229,17 @@ class PostureEstimator {
    * pose data.
    */
   void update_ideal_pose(PostureEstimating::Pose pose);
+
+  /**
+   * @brief Set the `pose_change_threshold` to allow user configuration. Note
+   * that this threshold is in radians and we set a maximum configurable value
+   * of 0.5 radians (28.64 degrees)
+   *
+   * @param threshold The updated threshold in the range [0..0.5] (radians)
+   * @return `true` If updating threshold succeeded
+   * @return `false` If updating threshold failed
+   */
+  bool set_pose_change_threshold(float threshold);
 
   /**
    * @brief Return a `PoseStatus` of the user's pose

--- a/src/posture_estimator.h
+++ b/src/posture_estimator.h
@@ -242,6 +242,15 @@ class PostureEstimator {
   bool set_pose_change_threshold(float threshold);
 
   /**
+   * @brief Get the currently set `pose_change_threshold`. Note that this
+   * threshold is in radians and we set a maximum configurable value of 0.5
+   * radians (28.64 degrees)
+   *
+   * @return `float` The current threshold in the range [0..0.5] (radians)
+   */
+  float get_pose_change_threshold(void);
+
+  /**
    * @brief Return a `PoseStatus` of the user's pose
    *
    * @param results `PostProcessing::ProcessedResults` struct containing user's

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -44,7 +44,7 @@ add_definitions (-DBOOST_TEST_DYN_LINK)
 create_test(test_iir ${test_libraries})
 create_test(test_post_processor ${test_libraries})
 create_test(test_pre_processor ${test_libraries} ${OpenCV_LIBS})
-create_test(test_posture_estimator ${test_libraries})
+create_test(test_posture_estimator ${test_libraries} ${OpenCV_LIBS})
 create_test(test_notifications ${test_libraries})
 
 SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread")

--- a/test/test_posture_estimator.cpp
+++ b/test/test_posture_estimator.cpp
@@ -189,7 +189,7 @@ BOOST_AUTO_TEST_CASE(GoodPostureNoChanges) {
   e.pose_change_threshold = M_PI / 4;
   e.checkGoodPosture();
 
-  BOOST_TEST(e.good_posture == true);
+  BOOST_TEST(e.posture_state == PostureEstimating::Good);
 }
 
 BOOST_AUTO_TEST_CASE(GoodPostureWithinThreshold) {
@@ -199,7 +199,7 @@ BOOST_AUTO_TEST_CASE(GoodPostureWithinThreshold) {
   e.pose_change_threshold = M_PI / 4;
   e.checkGoodPosture();
 
-  BOOST_TEST(e.good_posture == true);
+  BOOST_TEST(e.posture_state == PostureEstimating::Good);
 }
 
 BOOST_AUTO_TEST_CASE(GoodPostureOnThreshold) {
@@ -209,7 +209,7 @@ BOOST_AUTO_TEST_CASE(GoodPostureOnThreshold) {
   e.pose_change_threshold = M_PI / 4;
   e.checkGoodPosture();
 
-  BOOST_TEST(e.good_posture == true);
+  BOOST_TEST(e.posture_state == PostureEstimating::Good);
 }
 BOOST_AUTO_TEST_CASE(GoodPostureOutsideThreshold) {
   PostureEstimating::PostureEstimator e;
@@ -218,7 +218,7 @@ BOOST_AUTO_TEST_CASE(GoodPostureOutsideThreshold) {
   e.pose_change_threshold = M_PI / 6;
   e.checkGoodPosture();
 
-  BOOST_TEST(e.good_posture == false);
+  BOOST_TEST(e.posture_state == PostureEstimating::Bad);
 }
 
 BOOST_AUTO_TEST_CASE(CreatePoseFromTrustworthyResults) {
@@ -264,11 +264,11 @@ BOOST_AUTO_TEST_CASE(CreateProducedPoseStatusStructure) {
   helper_check_result(p.ideal_pose, ri);
   helper_check_result(p.current_pose, rc);
 
-  BOOST_CHECK_EQUAL(p.good_posture, true);
+  BOOST_CHECK_EQUAL(p.posture_state, PostureEstimating::Good);
   PostProcessing::ProcessedResults rch = helper_create_result();
   rch.body_parts[JointMin + 2] = {5, 3, PostProcessing::Trustworthy};
   PostureEstimating::PoseStatus pc = e.runEstimator(rch);
-  BOOST_CHECK_EQUAL(pc.good_posture, false);
+  BOOST_CHECK_EQUAL(pc.posture_state, PostureEstimating::Bad);
 
   for (int i = JointMin; i <= JointMax; i++) {
     BOOST_CHECK_EQUAL(pc.pose_changes.joints[i].joint, static_cast<Joint>(i));


### PR DESCRIPTION
# Details

- New `analysePosture` function in `PostureEstimator` is to be the main point we detect the various posture positions (we can trigger the notification and gui alert here as well when poor posture is detected etc)
- Update the Reset Posture button to set the `ideal_pose`
- Add functionality to change `pose_change_threshold` and a corresponding slider in settings (Closes #118)
- See below for the results:

# Screenshots/Gif (if appropriate)

1. Ideal Posture is not set as indicated by the blue lines
![Screenshot 2021-04-05 at 10 11 29](https://user-images.githubusercontent.com/45148261/113563141-18c9a780-95ff-11eb-94e3-ff1ef38e12b1.png)

1. When an ideal posture is set, the lines turn green to indicate you are currently in a good posture
![Screenshot 2021-04-05 at 10 12 08](https://user-images.githubusercontent.com/45148261/113563152-1bc49800-95ff-11eb-963c-9a56bdda2130.png)

1. When you move into a bad posture, this is detected and arrows are drawn to direct you back to your ideal posture
![Screenshot 2021-04-05 at 10 40 47](https://user-images.githubusercontent.com/45148261/113563157-1d8e5b80-95ff-11eb-96f6-29a73f8dc7a3.png)

1. When you return to the ideal posture, lines go back to green
![Screenshot 2021-04-05 at 10 41 05](https://user-images.githubusercontent.com/45148261/113563160-1ebf8880-95ff-11eb-9958-99309d1b6ce7.png)

# Checklist

## Code
- [ ] I have added some tests
- [x] I have run the tests locally to ensure they all pass by running `.scripts/build.sh -enable-testing`

## Documentation
Will do this in issue #109

Closes #104 