### PR TITLE
119 event drivenness

### DIFF
--- a/scripts/install_dependencies.sh
+++ b/scripts/install_dependencies.sh
@@ -20,10 +20,21 @@ if [ ! "$(printf '%s\n' "$MIN_CMAKE" "$CMAKE_VERSION" | sort -V | head -n1)" = "
       exit 1
 fi
 
+cd ..
+
+## Download cppTimer
+printf "Downloading cppTimer ...\n"
+if [ ! -d "cppTimer_src" ]; then
+  git clone https://github.com/berndporr/cppTimer.git cppTimer_src || exit 1
+  cd cppTimer_src
+  cmake .
+  make
+  sudo make install
+  cd..
+fi
 
 ## Download TFL code
 printf "Downloading TensorFlow ...\n"
-cd ..
 if [ ! -d "tensorflow_src" ]; then
   git clone https://github.com/tensorflow/tensorflow.git tensorflow_src || exit 1
 fi

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -15,19 +15,19 @@ add_subdirectory(gui ENABLE_EXPORTS)
 include_directories("${CMAKE_CURRENT_BINARY_DIR}/../../src/gui")
 
 set(NTFYSRC
-    notifications/notify.cpp
-    notifications/broadcaster.cpp
-    notifications/receiver.cpp
-    )
+notifications/notify.cpp
+notifications/broadcaster.cpp
+notifications/receiver.cpp
+)
 
 set(LIBSRC
-  iir.cpp
-  inference_core.cpp
-  framerate_settings.cpp
-  post_processor.cpp
-  pre_processor.cpp
-  posture_estimator.cpp
-  pipeline.cpp)
+iir.cpp
+inference_core.cpp
+framerate_settings.cpp
+post_processor.cpp
+pre_processor.cpp
+posture_estimator.cpp
+pipeline.cpp)
 
 # Set up OpenCV package
 set(OpenCV_DIR "${CMAKE_CURRENT_BINARY_DIR}/../../../opencv_build")
@@ -54,6 +54,7 @@ add_library(PosturePerfection_notify STATIC ${NTFYSRC})
 target_include_directories(PosturePerfection_static PUBLIC "${CMAKE_CURRENT_BINARY_DIR}/../flatbuffers/include")
 
 add_executable(PosturePerfection ${LIBSRC} main.cpp)
+target_link_libraries(PosturePerfection cpptimer rt)
 target_link_libraries(PosturePerfection tensorflow-lite PosturePerfection_gui ${CMAKE_DL_LIBS})
 target_link_libraries(PosturePerfection ${OpenCV_LIBS})
 target_include_directories(PosturePerfection PRIVATE "${CMAKE_CURRENT_BINARY_DIR}/../flatbuffers/include")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -15,19 +15,19 @@ add_subdirectory(gui ENABLE_EXPORTS)
 include_directories("${CMAKE_CURRENT_BINARY_DIR}/../../src/gui")
 
 set(NTFYSRC
-notifications/notify.cpp
-notifications/broadcaster.cpp
-notifications/receiver.cpp
+  notifications/notify.cpp
+  notifications/broadcaster.cpp
+  notifications/receiver.cpp
 )
 
 set(LIBSRC
-iir.cpp
-inference_core.cpp
-framerate_settings.cpp
-post_processor.cpp
-pre_processor.cpp
-posture_estimator.cpp
-pipeline.cpp)
+  iir.cpp
+  inference_core.cpp
+  framerate_settings.cpp
+  post_processor.cpp
+  pre_processor.cpp
+  posture_estimator.cpp
+  pipeline.cpp)
 
 # Set up OpenCV package
 set(OpenCV_DIR "${CMAKE_CURRENT_BINARY_DIR}/../../../opencv_build")

--- a/src/pipeline.h
+++ b/src/pipeline.h
@@ -214,16 +214,16 @@ class Buffer {
   PopResult<T> pop() {
     PopResult<T> front = PopResult<T>{T{}, false};
     while (*running) {
-      this->lock_out.lock();
+      lock_out.lock();
       if (size() != 0 || full) {
-        front = PopResult<T>{this->queue.at(front_index), true};
+        front = PopResult<T>{queue.at(front_index), true};
         front_index = (front_index + 1) % queue.size();
         full = false;
 
-        this->lock_out.unlock();
+        lock_out.unlock();
         break;
       }
-      this->lock_out.unlock();
+      lock_out.unlock();
     }
     return front;
   }

--- a/src/pipeline.h
+++ b/src/pipeline.h
@@ -384,29 +384,24 @@ class FrameGenerator : public CppTimer {
   std::mutex mutex;
 
   /**
-   * @brief Lock to ensure only a single thread can retrieve a frame at once
+   * @brief Condition variable to make callers of `next_frame()` wait until the
+   * next frame is ready to be processed.
    *
    */
-  std::mutex lock_out;
-
   std::condition_variable cv;
 
-  void timerEvent(void);
-
   /**
-   * @brief Time at which the previous capture took place
+   * @brief Continuously running thread to ensure the class always has the
+   * newest frame ready
    *
-   * A new capture should only take place after `frame_delay` time has passed
-   * since this `t_previous_capture`
+   * This cannot be in the body of the timer as OpenCV buffers camera frames.
+   * The only reliable way, at the time of writing, to get the newest frame is
+   * to constantly poll the camera so the OpenCV buffer is emptied. Not doing
+   * this would result in outdated frames being used in the pipeline, leading to
+   * a very noticeable system latency.
    *
    */
-  std::chrono::time_point<std::chrono::steady_clock> t_previous_capture;
-
-  /**
-   * @brief Currently set delay between frames
-   *
-   */
-  size_t frame_delay;
+  std::thread thread;
 
   /**
    * @brief Implementation of how to retrieve the next frame from the camera
@@ -415,20 +410,29 @@ class FrameGenerator : public CppTimer {
   void thread_body(void);
 
   /**
+   * @brief Timer to notify waiting threads they can process the current frame
+   *
+   * When the timer fires, at most one thread currently waiting in a
+   * `next_frame()` call will be notified and will start to process the frame.
+   *
+   * This timer controls the frame rate of the pipeline.
+   *
+   */
+  void timerEvent(void);
+
+  /**
    * @brief Flag to tell `thread_body` whether or not it should be running
    *
    */
   bool running = true;
 
  public:
-  void updated_framerate(size_t new_frame_delay);
   /**
    * @brief Construct a new Frame Generator object
    *
-   * @param framerate_settings Pointer to the `Pipeline`'s `FramerateSettings`
    * @throw `std::runtime_error` if the camera cannot be accessed
    */
-  explicit FrameGenerator(FramerateSettings* framerate_settings);
+  FrameGenerator(void);
 
   /**
    * @brief Destroy the Frame Generator object
@@ -437,6 +441,15 @@ class FrameGenerator : public CppTimer {
    *
    */
   ~FrameGenerator();
+
+  /**
+   * @brief Notify the `FrameGenerator` that the frame rate has changed
+   *
+   * The underlying timer is stopped and restarted with the new frame delay
+   *
+   * @param new_frame_delay New delay from one frame to the next in ms
+   */
+  void updated_framerate(size_t new_frame_delay);
 
   /**
    * @brief Get the newest frame

--- a/src/pipeline.h
+++ b/src/pipeline.h
@@ -22,6 +22,9 @@
 #ifndef SRC_PIPELINE_H_
 #define SRC_PIPELINE_H_
 
+#include <CppTimer.h>
+
+#include <condition_variable>
 #include <deque>
 #include <mutex>   //NOLINT [build/c++11]
 #include <thread>  //NOLINT [build/c++11]
@@ -342,7 +345,7 @@ struct RawFrame {
   cv::Mat raw_image;  ///< Raw `cv::Mat` (OpenCV) image
 };
 
-class FrameGenerator {
+class FrameGenerator : public CppTimer {
  private:
   /**
    * @brief Video stream handle
@@ -378,7 +381,7 @@ class FrameGenerator {
    * Enables the synchronisation of `id` and `current_frame`
    *
    */
-  std::mutex lock;
+  std::mutex mutex;
 
   /**
    * @brief Lock to ensure only a single thread can retrieve a frame at once
@@ -386,11 +389,9 @@ class FrameGenerator {
    */
   std::mutex lock_out;
 
-  /**
-   * @brief The thread that retrieves the newest frame from the camera
-   *
-   */
-  std::thread thread;
+  std::condition_variable cv;
+
+  void timerEvent(void);
 
   /**
    * @brief Time at which the previous capture took place

--- a/src/pipeline.h
+++ b/src/pipeline.h
@@ -24,7 +24,7 @@
 
 #include <CppTimer.h>
 
-#include <condition_variable>
+#include <condition_variable>  //NOLINT [build/c++11]
 #include <deque>
 #include <mutex>   //NOLINT [build/c++11]
 #include <thread>  //NOLINT [build/c++11]


### PR DESCRIPTION
# Details

- Change from busy waiting for frame delay to elapse to using a timer
- Add timer wrapper library to installation

# Checklist

## Code
- [ ] ~I have added some tests~
- [x] I have run the tests locally to ensure they all pass by running `.scripts/build.sh -enable-testing`

## Documentation
- [x] I have updated documentation appropriately (Doxygen)
- [ ] I have tested the updated GitHub Pages locally to ensure the changes to documentation render correctly (see this [Guidance](https://ese-peasy.github.io/PosturePerfection/guidance.html) page)

Closes #119 
