### PR TITLE
Create Bad Posture Notification

### DIFF
--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -86,11 +86,9 @@ GUI::MainWindow::MainWindow(Pipeline::Pipeline *pipeline, QWidget *parent)
 
   connect(pageComboBox, QOverload<int>::of(&QComboBox::activated),
           stackedWidget, &QStackedWidget::setCurrentIndex);
-  /*
-  connect(this, SIGNAL(currentFrameSignal(bool)), this,
+
+  connect(this, SIGNAL(currentGoodBadPosture(bool)), this,
           SLOT(updatePostureNotification(bool)));
-  */
-  updatePostureNotification(true);
 
   qRegisterMetaType<PostureEstimating::PostureState>(
       "PostureEstimating::PostureState");

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -87,8 +87,10 @@ GUI::MainWindow::MainWindow(Pipeline::Pipeline *pipeline, QWidget *parent)
   connect(pageComboBox, QOverload<int>::of(&QComboBox::activated),
           stackedWidget, &QStackedWidget::setCurrentIndex);
 
-  connect(this, SIGNAL(currentGoodBadPosture(bool)), this,
-          SLOT(updatePostureNotification(bool)));
+  qRegisterMetaType<PostureEstimating::PoseStatus>(
+      "PostureEstimating::PoseStatus");
+  connect(this, SIGNAL(currentGoodBadPosture(PostureEstimating::PoseStatus)),
+          this, SLOT(updatePostureNotification(PostureEstimating::PoseStatus)));
 
   // Output widgets to the user interface
   mainLayout->addWidget(title, 0, 0);
@@ -107,11 +109,12 @@ GUI::MainWindow::MainWindow(Pipeline::Pipeline *pipeline, QWidget *parent)
           SLOT(updateVideoFrame(cv::Mat)));
 }
 
-void GUI::MainWindow::updatePostureNotification(bool postureValue) {
+void GUI::MainWindow::updatePostureNotification(
+    PostureEstimating::PoseStatus poseStatus) {
   QWidget *postureNotificationBox = new QWidget;
   QGridLayout *postureNotificationLayout = new QGridLayout;
   QLabel *postureNotification = new QLabel();
-  if (postureValue) {
+  if (poseStatus.good_posture) {
     postureNotificationBox->setStyleSheet("background-color: green");
     postureNotification->setText("Good Posture");
   } else {
@@ -126,7 +129,7 @@ void GUI::MainWindow::updatePostureNotification(bool postureValue) {
 
 void GUI::MainWindow::updatePose(PostureEstimating::PoseStatus poseStatus) {
   currentPoseStatus = poseStatus;
-  emit currentGoodBadPosture(poseStatus.good_posture);
+  emit currentGoodBadPosture(poseStatus);
 }
 
 void GUI::MainWindow::createMainPage() {

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -114,12 +114,18 @@ void GUI::MainWindow::updatePostureNotification(
   QWidget *postureNotificationBox = new QWidget;
   QGridLayout *postureNotificationLayout = new QGridLayout;
   QLabel *postureNotification = new QLabel();
-  if (poseStatus.good_posture) {
-    postureNotificationBox->setStyleSheet("background-color: green");
-    postureNotification->setText("Good Posture");
+  // poseStatus.set_ideal_posture
+  if (false) {
+    if (poseStatus.good_posture) {
+      postureNotificationBox->setStyleSheet("background-color: green");
+      postureNotification->setText("Good Posture");
+    } else {
+      postureNotificationBox->setStyleSheet("background-color: red");
+      postureNotification->setText("Bad Posture");
+    }
   } else {
-    postureNotificationBox->setStyleSheet("background-color: red");
-    postureNotification->setText("Bad Posture");
+    postureNotificationBox->setStyleSheet("background-color: orange");
+    postureNotification->setText("Undefined");
   }
   postureNotification->setStyleSheet("QLabel {color : white; }");
   postureNotificationLayout->addWidget(postureNotification);

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -86,11 +86,17 @@ GUI::MainWindow::MainWindow(Pipeline::Pipeline *pipeline, QWidget *parent)
 
   connect(pageComboBox, QOverload<int>::of(&QComboBox::activated),
           stackedWidget, &QStackedWidget::setCurrentIndex);
+  /*
+  connect(this, SIGNAL(currentFrameSignal(bool)), this,
+          SLOT(updatePostureNotification(bool)));
+  */
+  updatePostureNotification(true);
 
   qRegisterMetaType<PostureEstimating::PostureState>(
       "PostureEstimating::PostureState");
   connect(this, SIGNAL(currentGoodBadPosture(PostureEstimating::PostureState)),
-          this, SLOT(updatePostureNotification(PostureEstimating::PostureState)));
+          this,
+          SLOT(updatePostureNotification(PostureEstimating::PostureState)));
 
   // Output widgets to the user interface
   mainLayout->addWidget(title, 0, 0);
@@ -111,7 +117,7 @@ GUI::MainWindow::MainWindow(Pipeline::Pipeline *pipeline, QWidget *parent)
 
 void GUI::MainWindow::updatePostureNotification(
     PostureEstimating::PostureState postureState) {
-  // Create notification widgets and set the minimum size shown 
+  // Create notification widgets and set the minimum size shown
   QWidget *postureNotificationBox = new QWidget;
   postureNotificationBox->setMinimumSize(200, 40);
   QGridLayout *postureNotificationLayout = new QGridLayout;

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -86,11 +86,9 @@ GUI::MainWindow::MainWindow(Pipeline::Pipeline *pipeline, QWidget *parent)
 
   connect(pageComboBox, QOverload<int>::of(&QComboBox::activated),
           stackedWidget, &QStackedWidget::setCurrentIndex);
-  /*
-  connect(this, SIGNAL(currentFrameSignal(bool)), this,
+
+  connect(this, SIGNAL(currentGoodBadPosture(bool)), this,
           SLOT(updatePostureNotification(bool)));
-  */
- updatePostureNotification(true);
 
   // Output widgets to the user interface
   mainLayout->addWidget(title, 0, 0);
@@ -113,10 +111,10 @@ void GUI::MainWindow::updatePostureNotification(bool postureValue) {
   QWidget *postureNotificationBox = new QWidget;
   QGridLayout *postureNotificationLayout = new QGridLayout;
   QLabel *postureNotification = new QLabel();
-  if(postureValue){
+  if (postureValue) {
     postureNotificationBox->setStyleSheet("background-color: green");
     postureNotification->setText("Good Posture");
-  }else{
+  } else {
     postureNotificationBox->setStyleSheet("background-color: red");
     postureNotification->setText("Bad Posture");
   }
@@ -128,6 +126,7 @@ void GUI::MainWindow::updatePostureNotification(bool postureValue) {
 
 void GUI::MainWindow::updatePose(PostureEstimating::PoseStatus poseStatus) {
   currentPoseStatus = poseStatus;
+  emit currentGoodBadPosture(poseStatus.good_posture);
 }
 
 void GUI::MainWindow::createMainPage() {

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -120,20 +120,27 @@ void GUI::MainWindow::updatePostureNotification(
 
   // Check if the ideal pose has been set and if so, display notification
   // according to the posture state
-  if (postureState != 2) {
-    if (postureState == 0) {
+  switch (postureState) {
+    case PostureEstimating::PostureState::Unset: {
+      postureNotificationBox->setStyleSheet("background-color: orange");
+      postureNotification->setText("Unset");
+      break;
+    }
+    case PostureEstimating::PostureState::Good: {
       postureNotificationBox->setStyleSheet("background-color: green");
       postureNotification->setText("Good Posture");
-    } else if (postureState == 1) {
-      postureNotificationBox->setStyleSheet("background-color: red");
-      postureNotification->setText("Bad Posture");
-    } else {
+      break;
+    }
+    case PostureEstimating::PostureState::Undefined: {
       postureNotificationBox->setStyleSheet("background-color: orange");
       postureNotification->setText("Undefined");
+      break;
     }
-  } else {
-    postureNotificationBox->setStyleSheet("background-color: orange");
-    postureNotification->setText("Unset");
+    case PostureEstimating::PostureState::Bad: {
+      postureNotificationBox->setStyleSheet("background-color: red");
+      postureNotification->setText("Bad Posture");
+      break;
+    }
   }
   postureNotification->setStyleSheet("QLabel {color : white; }");
   postureNotificationLayout->addWidget(postureNotification, 0, 0,

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -87,10 +87,10 @@ GUI::MainWindow::MainWindow(Pipeline::Pipeline *pipeline, QWidget *parent)
   connect(pageComboBox, QOverload<int>::of(&QComboBox::activated),
           stackedWidget, &QStackedWidget::setCurrentIndex);
 
-  qRegisterMetaType<PostureEstimating::PoseStatus>(
-      "PostureEstimating::PoseStatus");
-  connect(this, SIGNAL(currentGoodBadPosture(PostureEstimating::PoseStatus)),
-          this, SLOT(updatePostureNotification(PostureEstimating::PoseStatus)));
+  qRegisterMetaType<PostureEstimating::PostureState>(
+      "PostureEstimating::PostureState");
+  connect(this, SIGNAL(currentGoodBadPosture(PostureEstimating::PostureState)),
+          this, SLOT(updatePostureNotification(PostureEstimating::PostureState)));
 
   // Output widgets to the user interface
   mainLayout->addWidget(title, 0, 0);
@@ -110,8 +110,8 @@ GUI::MainWindow::MainWindow(Pipeline::Pipeline *pipeline, QWidget *parent)
 }
 
 void GUI::MainWindow::updatePostureNotification(
-    PostureEstimating::PoseStatus poseStatus) {
-  // Create notification widgets and set the minimum size shown
+    PostureEstimating::PostureState postureState) {
+  // Create notification widgets and set the minimum size shown 
   QWidget *postureNotificationBox = new QWidget;
   postureNotificationBox->setMinimumSize(200, 40);
   QGridLayout *postureNotificationLayout = new QGridLayout;
@@ -119,8 +119,8 @@ void GUI::MainWindow::updatePostureNotification(
 
   // Check if the ideal pose has been set and if so, display notification
   // according to the posture state
-  if (poseStatus.posture_state != 2) {
-    if (poseStatus.posture_state == 0) {
+  if (postureState != 2) {
+    if (postureState == 0) {
       postureNotificationBox->setStyleSheet("background-color: green");
       postureNotification->setText("Good Posture");
     } else {
@@ -140,7 +140,7 @@ void GUI::MainWindow::updatePostureNotification(
 
 void GUI::MainWindow::updatePose(PostureEstimating::PoseStatus poseStatus) {
   currentPoseStatus = poseStatus;
-  emit currentGoodBadPosture(poseStatus);
+  emit currentGoodBadPosture(poseStatus.posture_state);
 }
 
 void GUI::MainWindow::createMainPage() {

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -87,8 +87,10 @@ GUI::MainWindow::MainWindow(Pipeline::Pipeline *pipeline, QWidget *parent)
   connect(pageComboBox, QOverload<int>::of(&QComboBox::activated),
           stackedWidget, &QStackedWidget::setCurrentIndex);
 
-  connect(this, SIGNAL(currentGoodBadPosture(bool)), this,
-          SLOT(updatePostureNotification(bool)));
+  qRegisterMetaType<PostureEstimating::PoseStatus>(
+      "PostureEstimating::PoseStatus");
+  connect(this, SIGNAL(currentGoodBadPosture(PostureEstimating::PoseStatus)),
+          this, SLOT(updatePostureNotification(PostureEstimating::PoseStatus)));
 
   qRegisterMetaType<PostureEstimating::PostureState>(
       "PostureEstimating::PostureState");

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -87,11 +87,6 @@ GUI::MainWindow::MainWindow(Pipeline::Pipeline *pipeline, QWidget *parent)
   connect(pageComboBox, QOverload<int>::of(&QComboBox::activated),
           stackedWidget, &QStackedWidget::setCurrentIndex);
 
-  qRegisterMetaType<PostureEstimating::PoseStatus>(
-      "PostureEstimating::PoseStatus");
-  connect(this, SIGNAL(currentGoodBadPosture(PostureEstimating::PoseStatus)),
-          this, SLOT(updatePostureNotification(PostureEstimating::PoseStatus)));
-
   qRegisterMetaType<PostureEstimating::PostureState>(
       "PostureEstimating::PostureState");
   connect(this, SIGNAL(currentGoodBadPosture(PostureEstimating::PostureState)),
@@ -129,13 +124,16 @@ void GUI::MainWindow::updatePostureNotification(
     if (postureState == 0) {
       postureNotificationBox->setStyleSheet("background-color: green");
       postureNotification->setText("Good Posture");
-    } else {
+    } else if (postureState == 1) {
       postureNotificationBox->setStyleSheet("background-color: red");
       postureNotification->setText("Bad Posture");
+    } else {
+      postureNotificationBox->setStyleSheet("background-color: orange");
+      postureNotification->setText("Undefined");
     }
   } else {
     postureNotificationBox->setStyleSheet("background-color: orange");
-    postureNotification->setText("Undefined");
+    postureNotification->setText("Unset");
   }
   postureNotification->setStyleSheet("QLabel {color : white; }");
   postureNotificationLayout->addWidget(postureNotification, 0, 0,

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -86,6 +86,11 @@ GUI::MainWindow::MainWindow(Pipeline::Pipeline *pipeline, QWidget *parent)
 
   connect(pageComboBox, QOverload<int>::of(&QComboBox::activated),
           stackedWidget, &QStackedWidget::setCurrentIndex);
+  /*
+  connect(this, SIGNAL(currentFrameSignal(bool)), this,
+          SLOT(updatePostureNotification(bool)));
+  */
+ updatePostureNotification(true);
 
   // Output widgets to the user interface
   mainLayout->addWidget(title, 0, 0);
@@ -102,6 +107,23 @@ GUI::MainWindow::MainWindow(Pipeline::Pipeline *pipeline, QWidget *parent)
   qRegisterMetaType<cv::Mat>("cv::Mat");
   connect(this, SIGNAL(currentFrameSignal(cv::Mat)), this,
           SLOT(updateVideoFrame(cv::Mat)));
+}
+
+void GUI::MainWindow::updatePostureNotification(bool postureValue) {
+  QWidget *postureNotificationBox = new QWidget;
+  QGridLayout *postureNotificationLayout = new QGridLayout;
+  QLabel *postureNotification = new QLabel();
+  if(postureValue){
+    postureNotificationBox->setStyleSheet("background-color: green");
+    postureNotification->setText("Good Posture");
+  }else{
+    postureNotificationBox->setStyleSheet("background-color: red");
+    postureNotification->setText("Bad Posture");
+  }
+  postureNotification->setStyleSheet("QLabel {color : white; }");
+  postureNotificationLayout->addWidget(postureNotification);
+  postureNotificationBox->setLayout(postureNotificationLayout);
+  mainPageLayout->addWidget(postureNotificationBox, 2, 0, Qt::AlignCenter);
 }
 
 void GUI::MainWindow::updatePose(PostureEstimating::PoseStatus poseStatus) {

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -111,12 +111,16 @@ GUI::MainWindow::MainWindow(Pipeline::Pipeline *pipeline, QWidget *parent)
 
 void GUI::MainWindow::updatePostureNotification(
     PostureEstimating::PoseStatus poseStatus) {
+  // Create notification widgets and set the minimum size shown
   QWidget *postureNotificationBox = new QWidget;
+  postureNotificationBox->setMinimumSize(200, 40);
   QGridLayout *postureNotificationLayout = new QGridLayout;
   QLabel *postureNotification = new QLabel();
-  // poseStatus.set_ideal_posture
-  if (false) {
-    if (poseStatus.good_posture) {
+
+  // Check if the ideal pose has been set and if so, display notification
+  // according to the posture state
+  if (poseStatus.posture_state != 2) {
+    if (poseStatus.posture_state == 0) {
       postureNotificationBox->setStyleSheet("background-color: green");
       postureNotification->setText("Good Posture");
     } else {
@@ -128,7 +132,8 @@ void GUI::MainWindow::updatePostureNotification(
     postureNotification->setText("Undefined");
   }
   postureNotification->setStyleSheet("QLabel {color : white; }");
-  postureNotificationLayout->addWidget(postureNotification);
+  postureNotificationLayout->addWidget(postureNotification, 0, 0,
+                                       Qt::AlignCenter);
   postureNotificationBox->setLayout(postureNotificationLayout);
   mainPageLayout->addWidget(postureNotificationBox, 2, 0, Qt::AlignCenter);
 }

--- a/src/gui/mainwindow.h
+++ b/src/gui/mainwindow.h
@@ -114,6 +114,8 @@ class MainWindow : public QMainWindow {
    */
   void setOutputFramerate();
 
+  void updatePostureNotification(bool postureValue);
+
  public slots:
   /**
    * @brief Updates the threshold value

--- a/src/gui/mainwindow.h
+++ b/src/gui/mainwindow.h
@@ -163,14 +163,14 @@ class MainWindow : public QMainWindow {
   /**
    * @brief emit the newly captured frame
    *
-   * * @param currentFrame cv::Mat object containing the current captured frame
+   * @param currentFrame cv::Mat object containing the current captured frame
    */
   void currentFrameSignal(cv::Mat currentFrame);
 
   /**
    * @brief emit the newly captured good posture value
    *
-   * * @param postureState the current posture state
+   * @param postureState the current posture state
    */
   void currentGoodBadPosture(PostureEstimating::PostureState postureState);
 

--- a/src/gui/mainwindow.h
+++ b/src/gui/mainwindow.h
@@ -114,8 +114,6 @@ class MainWindow : public QMainWindow {
    */
   void setOutputFramerate();
 
-  void updatePostureNotification(bool postureValue);
-
  public slots:
   /**
    * @brief Updates the threshold value

--- a/src/gui/mainwindow.h
+++ b/src/gui/mainwindow.h
@@ -155,9 +155,9 @@ class MainWindow : public QMainWindow {
    * @brief update the posture notification using the posture status "good"
    * value
    *
-   * @param poseStatus posture status
+   * @param postureState the state of the posture currently captured
    */
-  void updatePostureNotification(PostureEstimating::PoseStatus poseStatus);
+  void updatePostureNotification(PostureEstimating::PostureState postureState);
 
  signals:
   /**
@@ -170,10 +170,9 @@ class MainWindow : public QMainWindow {
   /**
    * @brief emit the newly captured good posture value
    *
-   * * @param poseStatus the current posture status object
-   * posture
+   * * @param postureState the current posture state
    */
-  void currentGoodBadPosture(PostureEstimating::PoseStatus poseStatus);
+  void currentGoodBadPosture(PostureEstimating::PostureState postureState);
 
  private:
   /**

--- a/src/gui/mainwindow.h
+++ b/src/gui/mainwindow.h
@@ -155,9 +155,9 @@ class MainWindow : public QMainWindow {
    * @brief update the posture notification using the posture status "good"
    * value
    *
-   * @param postureValue posture status boolean value
+   * @param poseStatus posture status
    */
-  void updatePostureNotification(bool postureValue);
+  void updatePostureNotification(PostureEstimating::PoseStatus poseStatus);
 
  signals:
   /**
@@ -170,10 +170,10 @@ class MainWindow : public QMainWindow {
   /**
    * @brief emit the newly captured good posture value
    *
-   * * @param goodPosture boolean value indicating if the user has a good
+   * * @param poseStatus the current posture status object
    * posture
    */
-  void currentGoodBadPosture(bool goodPosture);
+  void currentGoodBadPosture(PostureEstimating::PoseStatus poseStatus);
 
  private:
   /**

--- a/src/gui/mainwindow.h
+++ b/src/gui/mainwindow.h
@@ -114,8 +114,6 @@ class MainWindow : public QMainWindow {
    */
   void setOutputFramerate();
 
-  void updatePostureNotification(bool postureValue);
-
  public slots:
   /**
    * @brief Updates the threshold value
@@ -153,12 +151,29 @@ class MainWindow : public QMainWindow {
    */
   void updateVideoFrame(cv::Mat currentFrame);
 
+  /**
+   * @brief update the posture notification using the posture status "good"
+   * value
+   *
+   * @param postureValue posture status boolean value
+   */
+  void updatePostureNotification(bool postureValue);
+
  signals:
   /**
    * @brief emit the newly captured frame
    *
+   * * @param currentFrame cv::Mat object containing the current captured frame
    */
   void currentFrameSignal(cv::Mat currentFrame);
+
+  /**
+   * @brief emit the newly captured good posture value
+   *
+   * * @param goodPosture boolean value indicating if the user has a good
+   * posture
+   */
+  void currentGoodBadPosture(bool goodPosture);
 
  private:
   /**

--- a/src/posture_estimator.cpp
+++ b/src/posture_estimator.cpp
@@ -296,6 +296,8 @@ void PostureEstimator::analysePosture(PostureEstimating::PoseStatus pose_status,
 
   cv::cvtColor(current_frame, current_frame, cv::COLOR_BGR2RGB);
 
+  if (posture_state == Undefined) return;
+
   if (posture_state == Bad) {
     display_pose_changes_needed(pose_changes, current_pose, current_frame);
   } else {

--- a/src/posture_estimator.cpp
+++ b/src/posture_estimator.cpp
@@ -139,7 +139,13 @@ void PostureEstimator::calculatePoseChanges() {
 }
 
 void PostureEstimator::checkGoodPosture() {
+  bool isUntrustworthy = true;
   for (int i = JointMin + 1; i <= JointMax - 2; i++) {
+    if (this->current_pose.joints[i].coord.status !=
+        PostProcessing::Untrustworthy) {
+      isUntrustworthy = false;
+    }
+
     if ((fabs(this->pose_changes.joints[i].upper_angle) <
          -(this->pose_change_threshold)) ||
         fabs(this->pose_changes.joints[i].upper_angle) >
@@ -148,7 +154,10 @@ void PostureEstimator::checkGoodPosture() {
       return;
     }
   }
-  if (!this->posture_state == Unset) {
+
+  if (isUntrustworthy == true) {
+    this->posture_state = Undefined;
+  } else if (!this->posture_state == Unset) {
     this->posture_state = Good;
   }
 }

--- a/src/posture_estimator.h
+++ b/src/posture_estimator.h
@@ -83,7 +83,7 @@ struct Pose {
  * `ideal_pose` has not been set by the user.
  *
  */
-enum PostureState { Good, Bad, Unset };
+enum PostureState { Good, Bad, Unset, Undefined };
 
 /**
  * @brief Creates an empty Pose object

--- a/test/test_posture_estimator.cpp
+++ b/test/test_posture_estimator.cpp
@@ -192,6 +192,7 @@ BOOST_AUTO_TEST_CASE(ChangesHandlesUntrustworthy) {
 
 BOOST_AUTO_TEST_CASE(GoodPostureNoChanges) {
   PostureEstimating::PostureEstimator e;
+  e.current_pose = helper_create_pose();
   e.update_ideal_pose(e.current_pose);
   e.pose_change_threshold = M_PI / 4;
   e.checkGoodPosture();
@@ -201,6 +202,7 @@ BOOST_AUTO_TEST_CASE(GoodPostureNoChanges) {
 
 BOOST_AUTO_TEST_CASE(GoodPostureWithinThreshold) {
   PostureEstimating::PostureEstimator e;
+  e.current_pose = helper_create_pose();
   e.update_ideal_pose(e.current_pose);
   e.pose_changes.joints[JointMin].lower_angle = M_PI / 6;
   e.pose_changes.joints[JointMin].upper_angle = -M_PI / 6;
@@ -212,6 +214,7 @@ BOOST_AUTO_TEST_CASE(GoodPostureWithinThreshold) {
 
 BOOST_AUTO_TEST_CASE(GoodPostureOnThreshold) {
   PostureEstimating::PostureEstimator e;
+  e.current_pose = helper_create_pose();
   e.update_ideal_pose(e.current_pose);
   e.pose_changes.joints[JointMin].lower_angle = M_PI / 4;
   e.pose_changes.joints[JointMin + 1].upper_angle = -M_PI / 4;
@@ -222,6 +225,7 @@ BOOST_AUTO_TEST_CASE(GoodPostureOnThreshold) {
 }
 BOOST_AUTO_TEST_CASE(GoodPostureOutsideThreshold) {
   PostureEstimating::PostureEstimator e;
+  e.current_pose = helper_create_pose();
   e.update_ideal_pose(e.current_pose);
   e.pose_changes.joints[JointMin].lower_angle = M_PI / 4;
   e.pose_changes.joints[JointMin + 1].upper_angle = -M_PI / 4;

--- a/test/test_posture_estimator.cpp
+++ b/test/test_posture_estimator.cpp
@@ -190,6 +190,35 @@ BOOST_AUTO_TEST_CASE(ChangesHandlesUntrustworthy) {
   }
 }
 
+BOOST_AUTO_TEST_CASE(StartInUnsetPostureState) {
+  PostureEstimating::PostureEstimator e;
+
+  BOOST_TEST(e.posture_state == PostureEstimating::Unset);
+}
+
+BOOST_AUTO_TEST_CASE(AllUntrustworthyJointsGivesUndefinedPostureState) {
+  PostureEstimating::PostureEstimator e;
+  // current_pose is initialised as a Pose with all Untrustworthy joints
+  e.update_ideal_pose(e.current_pose);
+  e.checkGoodPosture();
+
+  BOOST_TEST(e.posture_state == PostureEstimating::Undefined);
+}
+
+BOOST_AUTO_TEST_CASE(SettingIdealPostureChangesState) {
+  PostureEstimating::PostureEstimator e;
+  e.checkGoodPosture();
+
+  // Start in Unset state
+  BOOST_TEST(e.posture_state == PostureEstimating::Unset);
+
+  e.current_pose = helper_create_pose();
+  e.update_ideal_pose(e.current_pose);
+  e.checkGoodPosture();
+
+  BOOST_TEST(e.posture_state == PostureEstimating::Good);
+}
+
 BOOST_AUTO_TEST_CASE(GoodPostureNoChanges) {
   PostureEstimating::PostureEstimator e;
   e.current_pose = helper_create_pose();


### PR DESCRIPTION
# Details

- Created a notification to indicate if the user's posture is good, bad or the ideal posture has not been defined yet.
- Created functionality to ensure the correct notification is dynamically displayed using signal and slots.
- Set the minimum size of notification to ensure each one (good, bad and undefined) overlap perfectly.
 

# Screenshots

![Screenshot 2021-04-06 at 11 01 34](https://user-images.githubusercontent.com/35376993/113694314-7d503980-96c7-11eb-969b-1699c14be6f9.png)

# Checklist

## Code
- [ ] I have added some tests
- [x] I have run the tests locally to ensure they all pass by running `.scripts/build.sh -enable-testing`

## Documentation
- [x] I have updated documentation appropriately (GitHub Pages)
- [x] I have tested the updated GitHub Pages locally to ensure the changes to documentation render correctly (see this [Guidance](https://ese-peasy.github.io/PosturePerfection/guidance.html) page)

Closes #122 
